### PR TITLE
Support closeOnOutsideClick for touch devices

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -22,6 +22,7 @@ export default class Portal extends React.Component {
 
     if (this.props.closeOnOutsideClick) {
       document.addEventListener('mousedown', this.handleOutsideMouseClick);
+      document.addEventListener('touchstart', this.handleOutsideMouseClick);
     }
   }
 
@@ -59,6 +60,7 @@ export default class Portal extends React.Component {
 
     if (this.props.closeOnOutsideClick) {
       document.removeEventListener('mousedown', this.handleOutsideMouseClick);
+      document.removeEventListener('touchstart', this.handleOutsideMouseClick);
     }
 
     this.closePortal();


### PR DESCRIPTION
In my own experience just closing on click is not enought because this forces the user to "tap" the screen, and sometimes on mobile apps there's not so much blank space where a tap does not trigger an action, leading to bad UX

 User starting to scroll outside the portal should rather trigger portal closing for example