### PR TITLE
Fixed node requirement at package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "transportation"
   ],
   "engines": {
-    "node": "^4.4.1",
+    "node": "^4.1.2",
     "npm": "^3.3.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
The 1.0.0 package.json erroneously list node.js engine as `^4.4.1` while the latest version is only `4.1.2`. Npm would generate warnings whenever used.