### PR TITLE
React 0.14 Context Fix: Use renderSubtreeIntoContainer instead of render

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -82,7 +82,7 @@ export default class Portal extends React.Component {
       }
       document.body.appendChild(this.node);
     }
-    this.portal = ReactDOM.render(React.cloneElement(props.children, {closePortal: this.closePortal}), this.node);
+    this.portal = ReactDOM.unstable_renderSubtreeIntoContainer(this, React.cloneElement(props.children, {closePortal: this.closePortal}), this.node);
   }
 
   render() {

--- a/portal.js
+++ b/portal.js
@@ -121,7 +121,7 @@ var Portal = (function (_React$Component) {
         }
         document.body.appendChild(this.node);
       }
-      this.portal = _reactDom2['default'].render(_react2['default'].cloneElement(props.children, { closePortal: this.closePortal }), this.node);
+      this.portal = _reactDom2['default'].unstable_renderSubtreeIntoContainer(this, _react2['default'].cloneElement(props.children, { closePortal: this.closePortal }), this.node);
     }
   }, {
     key: 'render',


### PR DESCRIPTION
React 0.14 Context Fix: Use ReactDOM.unstable_renderSubtreeIntoContainer instead of ReactDOM.render so context gets passed to child components.

Context was changed with React 0.14.  Its not longer pass from the component that creates the component, but instead comes from the parent.  
ReactDOM.unstable_renderSubtreeIntoContainer will pass the context along to the children of Portal.