### PR TITLE
Don't render portal again if isOpened is not change

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -32,6 +32,9 @@ export default class Portal extends React.Component {
   }
 
   componentWillReceiveProps(newProps) {
+    if (this.props.isOpened === newProps.isOpened) {
+      return;
+    }
     // portal's 'is open' state is handled through the prop isOpened
     if (typeof newProps.isOpened !== 'undefined') {
       if (newProps.isOpened) {

--- a/portal.js
+++ b/portal.js
@@ -67,6 +67,9 @@ var Portal = (function (_React$Component) {
   }, {
     key: 'componentWillReceiveProps',
     value: function componentWillReceiveProps(newProps) {
+      if (this.props.isOpened === newProps.isOpened) {
+        return;
+      }
       // portal's 'is open' state is handled through the prop isOpened
       if (typeof newProps.isOpened !== 'undefined') {
         if (newProps.isOpened) {


### PR DESCRIPTION
This change avoid portal is rendered twice every time.