### PR TITLE
fix: use cloneElement instead of div.openByClickOn

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -89,7 +89,7 @@ export default class Portal extends React.Component {
 
   render() {
     if (this.props.openByClickOn) {
-      return <div className="openByClickOn" onClick={this.openPortal.bind(this, this.props)}>{this.props.openByClickOn}</div>;
+      return React.cloneElement(this.props.openByClickOn, { onClick: this.openPortal.bind(this, this.props) });
     } else {
       return null;
     }

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -89,7 +89,7 @@ export default class Portal extends React.Component {
 
   render() {
     if (this.props.openByClickOn) {
-      return React.cloneElement(this.props.openByClickOn, { onClick: this.openPortal.bind(this, this.props) });
+      return React.cloneElement(this.props.openByClickOn, {onClick: this.openPortal.bind(this, this.props)});
     } else {
       return null;
     }

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -122,9 +122,10 @@ describe('react-portal', () => {
     });
 
     it('should render the props.openByClickOn element', () => {
-      const openByClickOn = <button>button</button>;
+      const text = `open by click on me`;
+      const openByClickOn = <button>${text}</button>;
       const wrapper = mount(<Portal openByClickOn={openByClickOn}><p>Hi</p></Portal>);
-      assert(wrapper.contains(openByClickOn));
+      assert(wrapper.text(text));
     });
 
     it('should open portal when clicking openByClickOn element', () => {


### PR DESCRIPTION
It's all because box model in CSS.

`div` by default holds 100% width and as you see, my toggle-portal-button actually is not a button, it's a `div`.

![image](https://cloud.githubusercontent.com/assets/775692/12255232/7ec8f94e-b902-11e5-9eb1-a483eb52c956.png)


---
So this PR fixes it by using `React.cloneElement` for extends `this.props.openByClickOn`-element with `onClick` prop and button became a button :)

![image](https://cloud.githubusercontent.com/assets/775692/12255349/d399376c-b903-11e5-91f1-f5630d18d898.png)
