### PR TITLE
Avoid calling .bind() in render() and simplify openPortal()

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -12,7 +12,7 @@ export default class Portal extends React.Component {
   constructor() {
     super();
     this.state = {active: false};
-    this.openPortal = this.openPortal.bind(this);
+    this.handleWrapperClick = this.handleWrapperClick.bind(this);
     this.closePortal = this.closePortal.bind(this);
     this.handleOutsideMouseClick = this.handleOutsideMouseClick.bind(this);
     this.handleKeydown = this.handleKeydown.bind(this);
@@ -31,7 +31,7 @@ export default class Portal extends React.Component {
     }
 
     if (this.props.isOpened) {
-      this.openPortal(this.props);
+      this.openPortal();
     }
   }
 
@@ -89,17 +89,19 @@ export default class Portal extends React.Component {
 
   render() {
     if (this.props.openByClickOn) {
-      return <div className="openByClickOn" onClick={this.openPortal.bind(this, this.props)}>{this.props.openByClickOn}</div>;
+      return <div className="openByClickOn" onClick={this.handleWrapperClick}>{this.props.openByClickOn}</div>;
     } else {
       return null;
     }
   }
 
-  openPortal(props, e) {
-    if (e) {
-      e.preventDefault();
-      e.stopPropagation();
-    }
+  handleWrapperClick(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.openPortal();
+  }
+
+  openPortal(props = this.props) {
     this.setState({active: true});
     this.renderPortal(props);
 


### PR DESCRIPTION
Currently, `openPortal` is mixed with event handling logic and others. `.bind()` is thus required in `render()` in order to make things work.

However, `.bind()` creates a new function [every time `render()` is invoked](https://medium.com/@esamatti/react-js-pure-render-performance-anti-pattern-fb88c101332f#9bed), and in our case it can be avoided. Providing a click handler that is bound in constructor can eliminate `.bind()` in `render()`, and frees `openPortal()` from handling events as well.

Moreover, if we making the `props` argument optional, `openPortal` can be regarded as an exposed API to the parent component.

Thus, the [Don't read this](https://github.com/tajo/react-portal#dont-read-this) part in README could become:

```
<Portal ref="myPortal">
  <Modal title="My modal">
    Modal content
  </Modal>
</Portal>
```

```
this.refs.myPortal.openPortal()
```

which is actually a pattern adopted by [some](https://github.com/yuanyan/boron) [modal](https://github.com/Legitcode/modal) [implementations](http://marcio.github.io/react-skylight/).