### PR TITLE
close portal logic only if portal is active

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -66,9 +66,7 @@ export default class Portal extends React.Component {
       document.removeEventListener('touchstart', this.handleOutsideMouseClick);
     }
 
-    if (this.state.active) {
-      this.closePortal();
-    }
+    this.closePortal();
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -121,13 +119,15 @@ export default class Portal extends React.Component {
       this.setState({active: false});
     };
 
-    if (this.props.beforeClose) {
-      this.props.beforeClose(this.node, resetPortalState);
-    } else {
-      resetPortalState(this.node);
-    }
+    if (this.state.active) {
+      if (this.props.beforeClose) {
+        this.props.beforeClose(this.node, resetPortalState);
+      } else {
+        resetPortalState();
+      }
 
-    this.props.onClose();
+      this.props.onClose();
+    }
   }
 
   handleOutsideMouseClick(e) {

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -89,12 +89,22 @@ describe('react-portal', () => {
       const props = {isOpened: true, beforeClose: spy()};
       const wrapper = mount(<Portal {...props}><p>Hi</p></Portal>);
       wrapper.instance().closePortal();
+      assert(props.beforeClose.calledOnce);
       assert(props.beforeClose.calledWith(wrapper.instance().node));
+    });
+
+    it('should call props.beforeClose() only once even if closePortal is called multiple times', () => {
+      const props = {isOpened: true, beforeClose: spy((node, cb) => cb())};
+      const wrapper = mount(<Portal {...props}><p>Hi</p></Portal>);
+      wrapper.instance().closePortal();
+      wrapper.instance().closePortal();
+      assert(props.beforeClose.calledOnce);
     });
 
     it('should call props.onOpen() when portal opens', () => {
       const props = {isOpened: true, onOpen: spy()};
       const wrapper = mount(<Portal {...props}><p>Hi</p></Portal>);
+      assert(props.onOpen.calledOnce);
       assert(props.onOpen.calledWith(wrapper.instance().node));
     });
 
@@ -117,6 +127,14 @@ describe('react-portal', () => {
     it('should call props.onClose() when portal closes', () => {
       const props = {isOpened: true, onClose: spy()};
       const wrapper = mount(<Portal {...props}><p>Hi</p></Portal>);
+      wrapper.instance().closePortal();
+      assert(props.onClose.calledOnce);
+    });
+
+    it('should call props.onClose() only once even if closePortal is called multiple times', () => {
+      const props = {isOpened: true, onClose: spy()};
+      const wrapper = mount(<Portal {...props}><p>Hi</p></Portal>);
+      wrapper.instance().closePortal();
       wrapper.instance().closePortal();
       assert(props.onClose.calledOnce);
     });


### PR DESCRIPTION
move logic that was only in componentWillUnmount to be in closePortal
so that it applies also for beforeClose and on multiple calls on
closePortal.

follow up to https://github.com/tajo/react-portal/issues/45
even if user calls multiple times (wrongly) closePortal
his cosing callbacks won't get triggered multiple times.