### PR TITLE
Enable the library to be required by NodeJS

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": ["react", "es2015"],
+  "plugins": ["add-module-exports"],
   "env": {
     "development": {
       "presets": ["react-hmre"]

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-core": "^6.4.0",
     "babel-eslint": "^4.1.6",
     "babel-loader": "^6.2.1",
+    "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.0.1",


### PR DESCRIPTION
This allows `require('react-portal')` to work on NodeJS.