### PR TITLE
Simplify test script, put linting into mocha test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ node_js:
   - "5"
   - "4.1"
   - "4.0"
-before_script:
-  - npm install react react-dom
 script:
-  - npm run lint
   - npm test
   - npm run build
   - npm run build:examples

--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ Please, create issues and pull requests.
 git clone https://github.com/tajo/react-portal
 cd react-portal
 npm install
-npm install react react-dom
 npm start
 open http://localhost:3000
 ```
@@ -169,7 +168,6 @@ open http://localhost:3000
 **Don't forget to run this before every commit:**
 
 ```
-npm run lint
 npm test
 ```
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "build:examples": "npm run clean && npm run build:examples:webpack",
     "build:examples:webpack": "cross-env NODE_ENV=production webpack --config webpack.config.prod.js",
     "clean": "rimraf build",
-    "test": "cross-env NODE_ENV=test mocha --compilers js:babel-register",
-    "lint": "eslint examples lib test devServer.js",
+    "test": "mocha",
+    "lint": "mocha test/eslint_spec.js",
     "prepublish": "cross-env NODE_ENV=production npm run build"
   },
   "tags": [
@@ -58,7 +58,10 @@
     "express": "^4.13.3",
     "jsdom": "^7.2.2",
     "mocha": "^2.3.4",
+    "mocha-eslint": "^1.0.0",
+    "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.6",
+    "react-dom": "^0.14.7",
     "rimraf": "^2.5.0",
     "sinon": "^1.17.2",
     "tween.js": "^16.3.1",

--- a/test/eslint_spec.js
+++ b/test/eslint_spec.js
@@ -1,0 +1,1 @@
+require('mocha-eslint')('examples lib test devServer.js'.split(' '));

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = 'test';

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--compilers js:babel-register
+--require ./test/mocha.js


### PR DESCRIPTION
- linting can be done easier, when you put it into mocha test
- putting mocha options into file will make it possible to run in WebStorm interface, that has some benefits, comparing just to console test run
- puting react and react-dom into devDependencies will kill need to install them manually for developers and travis
- linting right now is part of test, so i killed extra step in README and travis 
- i left 'lint' script, for those who whant only linting. Maybe it make sense to remove it. I left it for now