### PR TITLE
prevent calling setState after component unmount

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -66,7 +66,7 @@ export default class Portal extends React.Component {
       document.removeEventListener('touchstart', this.handleOutsideMouseClick);
     }
 
-    this.closePortal();
+    this.closePortal(true);
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -108,7 +108,7 @@ export default class Portal extends React.Component {
     this.props.onOpen(this.node);
   }
 
-  closePortal() {
+  closePortal(isUnmounted = false) {
     const resetPortalState = () => {
       if (this.node) {
         ReactDOM.unmountComponentAtNode(this.node);
@@ -116,7 +116,9 @@ export default class Portal extends React.Component {
       }
       this.portal = null;
       this.node = null;
-      this.setState({active: false});
+      if (!isUnmounted) {
+        this.setState({active: false});
+      }
     };
 
     if (this.state.active) {

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -155,6 +155,15 @@ describe('react-portal', () => {
       unmountComponentAtNode(div);
       assert(props.onClose.calledOnce);
     });
+
+    it('should not call this.setState() if portal is unmounted', () => {
+      const div = document.createElement('div');
+      const props = {isOpened: true};
+      const wrapper = render(<Portal {...props}><p>Hi</p></Portal>, div);
+      spy(wrapper, 'setState');
+      unmountComponentAtNode(div);
+      assert.equal(wrapper.setState.callCount, 0);
+    });
   });
 
   describe('openByClickOn', () => {


### PR DESCRIPTION
Hey, Thanks for that useful component!
Also, I had some trouble with `setState` occuring after component unmount when spamming open/close very fast in my app. Here is a quick fix!

![portal](https://media.giphy.com/media/jPio8Xdb4qmwo/giphy.gif)