### PR TITLE
Portal should close with only a left button click

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -134,7 +134,7 @@ export default class Portal extends React.Component {
     if (!this.state.active) { return; }
 
     const root = findDOMNode(this.portal);
-    if (root.contains(e.target) || e.target.tagName === 'HTML') { return; }
+    if (root.contains(e.target) || e.target.tagName === 'HTML' || e.button !== 0) { return; }
 
     e.stopPropagation();
     this.closePortal();

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -199,8 +199,15 @@ describe('react-portal', () => {
     it('closeOnOutsideClick', () => {
       mount(<Portal closeOnOutsideClick isOpened><p>Hi</p></Portal>);
       assert.equal(document.body.childElementCount, 1);
-      const mouseEvent = new window.MouseEvent('mousedown', {view: window});
-      document.dispatchEvent(mouseEvent);
+
+      // Should not close when outside click isn't a main click
+      const rightClickMouseEvent = new window.MouseEvent('mousedown', {view: window, button: 2});
+      document.dispatchEvent(rightClickMouseEvent);
+      assert.equal(document.body.childElementCount, 1);
+
+      // Should close when outside click is a main click (typically left button click)
+      const leftClickMouseEvent = new window.MouseEvent('mousedown', {view: window, button: 0});
+      document.dispatchEvent(leftClickMouseEvent);
       assert.equal(document.body.childElementCount, 0);
     });
   });


### PR DESCRIPTION
When `closeOnOutsideClick` is set, an outside click will close only when
the button clicked was the main button (typically a left-button click)
rather than any mouse event button.