### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,6 @@
     "portal",
     "transportation"
   ],
-  "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
-  },
   "devDependencies": {
     "babel-cli": "^6.4.0",
     "babel-core": "^6.4.0",


### PR DESCRIPTION
Many popular libraries stopped using these, it allows for more flexible dependency versions. react-portal also seems to work fine with v15.0.0-rc.1