### PR TITLE
fix handleOutsideMouseClick on safari(iPhone)

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -136,7 +136,7 @@ export default class Portal extends React.Component {
     if (!this.state.active) { return; }
 
     const root = findDOMNode(this.portal);
-    if (root.contains(e.target) || e.button !== 0) { return; }
+    if (root.contains(e.target) || (e.button && e.button !== 0)) { return; }
 
     e.stopPropagation();
     this.closePortal();


### PR DESCRIPTION
TouchEvent on safari(iOS platform) doesn't have a `button` property.
So we have to check it before `e.button !== 0`.