### PR TITLE
Fix bug re-open on close (flicker - having outside click listener)

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -98,6 +98,10 @@ export default class Portal extends React.Component {
   handleWrapperClick(e) {
     e.preventDefault();
     e.stopPropagation();
+
+    // when having outside mouse click listener don't open portal if it's already open
+    if (this.state.active) { return; }
+
     this.openPortal();
   }
 


### PR DESCRIPTION
The last change (mouse up) didn't fix the bug of re-open, the handleWrapperClick function still been called when the component has an outside click listener. I think an option to prevent this error could be check if the Portal is already open when this function is called. If the Portal is already open then return, doesn't make sense to re-open if that's already open. 

I have checked the examples before and after and with this implementation avoid the flicker or re-open. The other examples still working properly (as expected)