### PR TITLE
Using this.props.closePortal is working properly now.

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -120,7 +120,7 @@ export default class Portal extends React.Component {
       }
       this.portal = null;
       this.node = null;
-      if (!isUnmounted) {
+      if (isUnmounted !== true) {
         this.setState({active: false});
       }
     };


### PR DESCRIPTION
This methos is getting the event in the place of the param isUnmounted when using this method in a children. So `if (!isUnmounted) ` never will be true and the active state never gonna change to false, even when the portal is closed. 