### PR TITLE
Build to UMD format

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": ["react", "es2015"],
-  "plugins": ["add-module-exports"],
+  "plugins": ["transform-es2015-modules-umd"],
   "env": {
     "development": {
       "presets": ["react-hmre"]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.1",
-    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-es2015-modules-umd": "^6.8.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.0.1",


### PR DESCRIPTION
This makes react-portal support AMD and 1998 script tags. React supports these styles (we use react with require.js in our project) so I think that react-portal should support them as well.

Note that the "transform-es2015-modules-umd" plugin also "adds module exports" so that plugin is no longer needed.