### PR TITLE
Add ability to disable adding closePortal prop

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -153,7 +153,7 @@ export default class Portal extends React.Component {
 
     let children = props.children;
     // https://gist.github.com/jimfb/d99e0678e9da715ccf6454961ef04d1b
-    if (typeof props.children.type === 'function') {
+    if (!props.noInjectedClose && typeof props.children.type === 'function') {
       children = React.cloneElement(props.children, { closePortal: this.closePortal });
     }
 
@@ -180,6 +180,7 @@ Portal.propTypes = {
   openByClickOn: React.PropTypes.element,
   closeOnEsc: React.PropTypes.bool,
   closeOnOutsideClick: React.PropTypes.bool,
+  noInjectedClose: React.PropTypes.bool,
   isOpened: React.PropTypes.bool,
   onOpen: React.PropTypes.func,
   onClose: React.PropTypes.func,

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -72,6 +72,18 @@ describe('react-portal', () => {
     assert.equal(closePortal, wrapper.instance().closePortal);
   });
 
+  it('should not pass Portal.closePortal when excluded', () => {
+    let closePortal;
+    /*eslint-disable*/
+    const Child = (props) => {
+      closePortal = props.closePortal;
+      return <p>Hi</p>;
+    };
+    /*eslint-enable*/
+    mount(<Portal isOpened noInjectedClose><Child /></Portal>);
+    assert.equal(closePortal, undefined);
+  });
+
   it('should add className to the portal\'s wrapping node', () => {
     mount(<Portal className="some-class" isOpened><p>Hi</p></Portal>);
     assert.equal(document.body.lastElementChild.className, 'some-class');


### PR DESCRIPTION
The existing logic to not pass `closePortal` works if you are wrapping something like a `<div>` element, but fails if it is wrapping a function which doesn't filter it's own properties. In our case, we are using rebass's `<Fixed>` component inside `<Portal>`. `<Fixed>`, for better or worse, takes all properties and blindly passes them to a div component. Since `<Portal>` doesn't know this, it was causing the same react unknown props error.

Our temporary solution was to wrap our code in another div so `<Portal>` doesn't inject `closePortal`, but this pull request adds a `noInjectedClose` parameter which will disable the property injection. A test was also added and passes.
