### PR TITLE
Portal reopens if parent component sets its state immediately after .closePortal()

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -9,7 +9,6 @@ export default class Portal extends React.Component {
 
   constructor() {
     super();
-    this.state = { active: false };
     this.handleWrapperClick = this.handleWrapperClick.bind(this);
     this.closePortal = this.closePortal.bind(this);
     this.handleOutsideMouseClick = this.handleOutsideMouseClick.bind(this);

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -39,19 +39,19 @@ export default class Portal extends React.Component {
     // portal's 'is open' state is handled through the prop isOpened
     if (typeof newProps.isOpened !== 'undefined') {
       if (newProps.isOpened) {
-        if (this.state.active) {
+        if (this.active) {
           this.renderPortal(newProps);
         } else {
           this.openPortal(newProps);
         }
       }
-      if (!newProps.isOpened && this.state.active) {
+      if (!newProps.isOpened && this.active) {
         this.closePortal();
       }
     }
 
     // portal handles its own 'is open' state
-    if (typeof newProps.isOpened === 'undefined' && this.state.active) {
+    if (typeof newProps.isOpened === 'undefined' && this.active) {
       this.renderPortal(newProps);
     }
   }
@@ -76,12 +76,12 @@ export default class Portal extends React.Component {
   handleWrapperClick(e) {
     e.preventDefault();
     e.stopPropagation();
-    if (this.state.active) { return; }
+    if (this.active) { return; }
     this.openPortal();
   }
 
   openPortal(props = this.props) {
-    this.setState({ active: true });
+    this.active = true;
     this.renderPortal(props);
     this.props.onOpen(this.node);
   }
@@ -95,11 +95,11 @@ export default class Portal extends React.Component {
       this.portal = null;
       this.node = null;
       if (isUnmounted !== true) {
-        this.setState({ active: false });
+        this.active = false;
       }
     };
 
-    if (this.state.active) {
+    if (this.active) {
       if (this.props.beforeClose) {
         this.props.beforeClose(this.node, resetPortalState);
       } else {
@@ -111,7 +111,7 @@ export default class Portal extends React.Component {
   }
 
   handleOutsideMouseClick(e) {
-    if (!this.state.active) { return; }
+    if (!this.active) { return; }
 
     const root = findDOMNode(this.portal);
     if (root.contains(e.target) || (e.button && e.button !== 0)) { return; }
@@ -121,7 +121,7 @@ export default class Portal extends React.Component {
   }
 
   handleKeydown(e) {
-    if (e.keyCode === KEYCODES.ESCAPE && this.state.active) {
+    if (e.keyCode === KEYCODES.ESCAPE && this.active) {
       this.closePortal();
     }
   }


### PR DESCRIPTION
Minimal example:

``` javascript
class NotClosingPortalContainer extends React.Component {
    constructor() {
        super(...arguments)
        this.state = {counter: 0}
        this.handleClick = () => {
            this.setState({counter: this.state.counter + 1})
        }
    }

    render() {
        return (
            <div>
                {this.state.counter}
                <Portal openByClickOn={<button>open</button>}>
                    <InsidePortal onClick={this.handleClick}>+1</InsidePortal>
                </Portal>
            </div>
        )
    }
}


class InsidePortal extends React.Component {
    constructor() {
        super(...arguments)
        this.handleClick = () => {
            this.props.closePortal()
            this.props.onClick()
        }
    }

    render() {
        return <button onClick={this.handleClick}>+1</button>
    }
}
```

Expected behaviour:
- `NotClosingPortalContainer` displays counter and button to open portal
- in the portal is a button that should increase counter and close the portal

What actually happens:
- after clicking button inside portal it is closed and then immediately reopened

I think this happens:
1. in `Portal#closePortal` `this.setState({ active: false })` is called, but it works asynchronously
2. `NotClosingPortalContainer#handleClick` in `this.setState(...)` is called
3. `NotClosingPortalContainer` rerenders **before** `Portal#state.active` actual value is set to `false`
4. `Portal` receives new props and opens portal (because `Portal#state.active` still equals `true`)
5. Everything ends in a weird state

I fixed this by basically replacing `Portal#state.active` with `Portal#active` but it feels dirty. I'm pretty new to React so maybe there is a better solution? 

Tests are passing.
