### PR TITLE
Added functionality for portal targets

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Portal from '../lib/portal.js';
+import PortalTarget from '../lib/portaltarget';
 import PseudoModal from './pseudomodal';
 import LoadingBar from './loadingbar';
 import AbsolutePosition from './absoluteposition';
@@ -83,6 +84,7 @@ export default class App extends React.Component {
       </button>
     );
     const button4 = <button style={buttonStyles}>Animation Example</button>;
+    const button5 = <button style={buttonStyles}>Console</button>;
 
     return (
       <div style={{ border: '2px solid red', margin: 10, padding: 10 }}>
@@ -101,15 +103,21 @@ export default class App extends React.Component {
         </Portal>
 
         <button onClick={(e) => this.toggleLoadingBar(e)} style={buttonStyles}>
-          {this.state.isPortalOpened ? 'Close the second portal' : 'Open the second portal'}
+          {this.state.isPortalOpened ? 'Close the sidebar portal' : 'Open the sidebar portal'}
         </button>
-        <Portal isOpened={this.state.isPortalOpened} testProp={this.state.someValue}>
+        <Portal target="sidebar" isOpened={this.state.isPortalOpened} testProp={this.state.someValue}>
           <LoadingBar />
         </Portal>
 
         <Portal closeOnOutsideClick onClose={this.onClose} openByClickOn={button2}>
           <div style={{ border: '1px solid black', margin: 10, padding: 10 }}>
             <p>Click anywhere outside of this portal to close it.</p>
+          </div>
+        </Portal>
+
+        <Portal target="console" className="console-portal" closeOnEsc onClose={this.onClose} openByClickOn={button5}>
+          <div style={{ border: '1px solid black', margin: 10, padding: 10 }}>
+            <p>Hit ESC to close.</p>
           </div>
         </Portal>
 
@@ -146,6 +154,9 @@ export default class App extends React.Component {
             on both click outside and on esc press</p>
           </div>
         </Portal>
+
+        <PortalTarget name="sidebar" style={{ position: 'fixed', top: 0, right: 0, bottom: 0, maxWidth: 250, background: '#eee', zIndex: 100 }} />
+        <PortalTarget className="console" name="console" style={{ position: 'fixed', bottom: 0, left: 0, right: 0, background: '#eee', zIndex: 100 }} />
       </div>
     );
   }

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -90,7 +90,7 @@ export default class Portal extends React.Component {
     const resetPortalState = () => {
       if (this.node) {
         ReactDOM.unmountComponentAtNode(this.node);
-        document.body.removeChild(this.node);
+        this.node.parentNode.removeChild(this.node);
       }
       this.portal = null;
       this.node = null;
@@ -145,7 +145,14 @@ export default class Portal extends React.Component {
       this.node = document.createElement('div');
       // apply CSS before the node is added to the DOM to avoid needless reflows
       this.applyClassNameAndStyle(props);
-      document.body.appendChild(this.node);
+      if (props.target) {
+        var targetElement = document.querySelector('[data-portaltarget=' + props.target + ']');
+        if (targetElement) {
+          targetElement.appendChild(this.node);
+        }
+      } else {
+        document.body.appendChild(this.node);
+      }
     } else {
       // update CSS when new props arrive
       this.applyClassNameAndStyle(props);

--- a/lib/portaltarget.js
+++ b/lib/portaltarget.js
@@ -1,0 +1,8 @@
+import React from 'react';
+
+export default class PortalTarget extends React.Component {
+  render() {
+    const { name } = this.props;
+    return <div className={this.props.className} style={this.props.style} data-portaltarget={name}>{this.props.children}</div>
+  }
+}


### PR DESCRIPTION
support for portal targets. A way to place portals in targeted places in the document, rather than always at the bottom.

Fixes issue: https://github.com/tajo/react-portal/issues/99
