### PR TITLE
Option to toggle portal when clicking `openByClickOn` element

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ This callback is called when the portal closes and after beforeClose.
 #### onUpdate: func
 This callback is called when the portal is (re)rendered.
 
+#### togglesOnClick: bool
+If true, subsequent clicks on the element specified by `openByClickOn` will toggle the portal instead of keeping it always opened. Defaults to `false`.
 
 ## Tips & Tricks
 - Does your modal have a fullscreen overlay and the `closeOnOutsideClick` doesn't work? [There is a simple solution](https://github.com/tajo/react-portal/issues/2#issuecomment-92058826).

--- a/examples/index.js
+++ b/examples/index.js
@@ -83,6 +83,7 @@ export default class App extends React.Component {
       </button>
     );
     const button4 = <button style={buttonStyles}>Animation Example</button>;
+    const button5 = <button style={buttonStyles}>Toggle portal</button>;
 
     return (
       <div style={{ border: '2px solid red', margin: 10, padding: 10 }}>
@@ -144,6 +145,15 @@ export default class App extends React.Component {
             <p>Trigger Animations, or any arbitrary function,{' '}
             before removing the portal from the DOM, animates out{' '}
             on both click outside and on esc press</p>
+          </div>
+        </Portal>
+
+        <Portal
+          openByClickOn={button5}
+          togglesOnClick
+        >
+          <div style={{ border: '1px solid black', margin: 10, padding: 10 }}>
+            <p>Click again on the button to hide this.</p>
           </div>
         </Portal>
       </div>

--- a/examples/index.js
+++ b/examples/index.js
@@ -150,6 +150,8 @@ export default class App extends React.Component {
 
         <Portal
           openByClickOn={button5}
+          closeOnEsc
+          closeOnOutsideClick
           togglesOnClick
         >
           <div style={{ border: '1px solid black', margin: 10, padding: 10 }}>

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -7,6 +7,15 @@ const KEYCODES = {
   ESCAPE: 27,
 };
 
+// IE < 9
+const preventDefault = (event) => {
+  if (event.preventDefault === undefined) {
+    event.returnValue = false; // eslint-disable-line no-param-reassign
+  } else {
+    event.preventDefault();
+  }
+};
+
 export default class Portal extends React.Component {
 
   constructor() {
@@ -16,6 +25,8 @@ export default class Portal extends React.Component {
     this.closePortal = this.closePortal.bind(this);
     this.handleOutsideMouseClick = this.handleOutsideMouseClick.bind(this);
     this.handleKeydown = this.handleKeydown.bind(this);
+    this.handleWrapperClick = this.handleWrapperClick.bind(this);
+    this.triggerElementRef = this.triggerElementRef.bind(this);
     this.portal = null;
     this.node = null;
   }
@@ -26,7 +37,7 @@ export default class Portal extends React.Component {
     }
 
     if (this.props.closeOnOutsideClick) {
-      document.addEventListener('mouseup', this.handleOutsideMouseClick);
+      document.addEventListener('click', this.handleOutsideMouseClick);
       document.addEventListener('touchstart', this.handleOutsideMouseClick);
     }
 
@@ -66,7 +77,7 @@ export default class Portal extends React.Component {
     }
 
     if (this.props.closeOnOutsideClick) {
-      document.removeEventListener('mouseup', this.handleOutsideMouseClick);
+      document.removeEventListener('click', this.handleOutsideMouseClick);
       document.removeEventListener('touchstart', this.handleOutsideMouseClick);
     }
 
@@ -74,7 +85,7 @@ export default class Portal extends React.Component {
   }
 
   handleWrapperClick(e) {
-    e.preventDefault();
+    preventDefault(e);
     e.stopPropagation();
 
     if (this.props.togglesOnClick) {
@@ -152,6 +163,22 @@ export default class Portal extends React.Component {
     }
   }
 
+  triggerElementRef(triggerElement) {
+    const domElement = findDOMNode(triggerElement);
+
+    if (this.triggerElement && this.triggerElement !== domElement) {
+      this.triggerElement.removeEventListener('click', this.handleWrapperClick);
+      this.triggerElement.removeEventListener('touchstart', this.handleWrapperClick);
+    }
+
+    if (domElement && this.triggerElement !== domElement) {
+      domElement.addEventListener('click', this.handleWrapperClick);
+      domElement.addEventListener('touchstart', this.handleWrapperClick);
+    }
+
+    this.triggerElement = domElement;
+  }
+
   renderPortal(props) {
     if (!this.node) {
       this.node = document.createElement('div');
@@ -179,7 +206,9 @@ export default class Portal extends React.Component {
 
   render() {
     if (this.props.openByClickOn) {
-      return React.cloneElement(this.props.openByClickOn, { onClick: this.handleWrapperClick });
+      return React.cloneElement(this.props.openByClickOn, {
+        ref: this.triggerElementRef,
+      });
     }
     return null;
   }

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -70,8 +70,8 @@ export default class Portal extends React.Component {
     }
 
     if (this.props.closeOnOutsideClick) {
-      document.removeEventListener('click', this.handleOutsideMouseClick);
-      document.removeEventListener('touchstart', this.handleOutsideMouseClick);
+      document.removeEventListener('click', this.handleOutsideMouseClick, true);
+      document.removeEventListener('touchstart', this.handleOutsideMouseClick, true);
     }
 
     this.closePortal(true);

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -34,8 +34,8 @@ export default class Portal extends React.Component {
     }
 
     if (this.props.closeOnOutsideClick) {
-      document.addEventListener('click', this.handleOutsideMouseClick);
-      document.addEventListener('touchstart', this.handleOutsideMouseClick);
+      document.addEventListener('click', this.handleOutsideMouseClick, true);
+      document.addEventListener('touchstart', this.handleOutsideMouseClick, true);
     }
 
     if (this.props.isOpen) {
@@ -79,7 +79,6 @@ export default class Portal extends React.Component {
 
   handleWrapperClick(e) {
     preventDefault(e);
-    e.stopPropagation();
 
     if (this.props.togglesOnClick) {
       this.togglePortal();
@@ -129,9 +128,14 @@ export default class Portal extends React.Component {
     if (!this.state.active) { return; }
 
     const root = findDOMNode(this.portal);
-    if (root.contains(e.target) || (e.button && e.button !== 0)) { return; }
+    if (
+      root.contains(e.target) ||
+      (e.button && e.button !== 0) ||
+      e.target === this.triggerElement
+    ) {
+      return;
+    }
 
-    e.stopPropagation();
     this.closePortal();
   }
 

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -177,6 +177,10 @@ export default class Portal extends React.Component {
     }
 
     this.triggerElement = domElement;
+
+    if (typeof this.props.openByClickOn.ref === 'function') {
+      this.props.openByClickOn.ref(triggerElement);
+    }
   }
 
   renderPortal(props) {

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -76,8 +76,20 @@ export default class Portal extends React.Component {
   handleWrapperClick(e) {
     e.preventDefault();
     e.stopPropagation();
-    if (this.state.active) { return; }
-    this.openPortal();
+
+    if (this.props.togglesOnClick) {
+      this.togglePortal();
+    } else if (!this.state.active) {
+      this.openPortal();
+    }
+  }
+
+  togglePortal() {
+    if (this.state.active) {
+      this.closePortal();
+    } else {
+      this.openPortal();
+    }
   }
 
   openPortal(props = this.props) {
@@ -185,10 +197,12 @@ Portal.propTypes = {
   onClose: React.PropTypes.func,
   beforeClose: React.PropTypes.func,
   onUpdate: React.PropTypes.func,
+  togglesOnClick: React.PropTypes.bool,
 };
 
 Portal.defaultProps = {
   onOpen: () => {},
   onClose: () => {},
   onUpdate: () => {},
+  togglesOnClick: false,
 };

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -194,8 +194,27 @@ describe('react-portal', () => {
     it('should open portal when clicking openByClickOn element', () => {
       const openByClickOn = <button>button</button>;
       const wrapper = mount(<Portal openByClickOn={openByClickOn}><p>Hi</p></Portal>);
-      wrapper.find('button').simulate('click');
-      assert.equal(document.body.lastElementChild, wrapper.instance().node);
+      const instance = wrapper.instance();
+      spy(instance, 'openPortal');
+      instance.triggerElement.click();
+      assert(instance.openPortal.calledOnce);
+    });
+
+    it('should allow custom components', () => {
+      class CustomComponent extends React.PureComponent {
+        render() {
+          return (
+            <button>button</button>
+          );
+        }
+      }
+
+      const openByClickOn = <CustomComponent />;
+      const wrapper = mount(<Portal openByClickOn={openByClickOn}><p>Hi</p></Portal>);
+      const instance = wrapper.instance();
+      spy(instance, 'openPortal');
+      instance.triggerElement.click();
+      assert(instance.openPortal.calledOnce);
     });
   });
 
@@ -211,7 +230,7 @@ describe('react-portal', () => {
           );
           const instance = wrapper.instance();
           spy(instance, 'openPortal');
-          wrapper.find('button').simulate('click');
+          instance.triggerElement.click();
           assert(instance.openPortal.calledOnce);
         });
       });
@@ -226,7 +245,7 @@ describe('react-portal', () => {
           );
           const instance = wrapper.instance();
           spy(instance, 'closePortal');
-          wrapper.find('button').simulate('click');
+          instance.triggerElement.click();
           assert(!instance.closePortal.called);
         });
       });
@@ -243,7 +262,7 @@ describe('react-portal', () => {
           );
           const instance = wrapper.instance();
           spy(instance, 'openPortal');
-          wrapper.find('button').simulate('click');
+          instance.triggerElement.click();
           assert(instance.openPortal.calledOnce);
         });
       });
@@ -258,7 +277,7 @@ describe('react-portal', () => {
           );
           const instance = wrapper.instance();
           spy(instance, 'closePortal');
-          wrapper.find('button').simulate('click');
+          instance.triggerElement.click();
           assert(instance.closePortal.calledOnce);
         });
       });
@@ -287,12 +306,12 @@ describe('react-portal', () => {
       assert.equal(document.body.childElementCount, 1);
 
       // Should not close when outside click isn't a main click
-      const rightClickMouseEvent = new window.MouseEvent('mouseup', { view: window, button: 2 });
+      const rightClickMouseEvent = new window.MouseEvent('click', { view: window, button: 2 });
       document.dispatchEvent(rightClickMouseEvent);
       assert.equal(document.body.childElementCount, 1);
 
       // Should close when outside click is a main click (typically left button click)
-      const leftClickMouseEvent = new window.MouseEvent('mouseup', { view: window, button: 0 });
+      const leftClickMouseEvent = new window.MouseEvent('click', { view: window, button: 0 });
       document.dispatchEvent(leftClickMouseEvent);
       assert.equal(document.body.childElementCount, 0);
     });

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -199,6 +199,72 @@ describe('react-portal', () => {
     });
   });
 
+  describe('togglesOnClick', () => {
+    context('if false', () => {
+      context('if the portal is closed', () => {
+        it('should open portal when clicking openByClickOn element', () => {
+          const openByClickOn = <button>button</button>;
+          const wrapper = mount(
+            <Portal openByClickOn={openByClickOn} togglesOnClick={false} isOpened={false}>
+              <p>Hi</p>
+            </Portal>
+          );
+          const instance = wrapper.instance();
+          spy(instance, 'openPortal');
+          wrapper.find('button').simulate('click');
+          assert(instance.openPortal.calledOnce);
+        });
+      });
+
+      context('if the portal is opened', () => {
+        it('should keep the portal opened when clicking openByClickOn element', () => {
+          const openByClickOn = <button>button</button>;
+          const wrapper = mount(
+            <Portal openByClickOn={openByClickOn} togglesOnClick={false} isOpened>
+              <p>Hi</p>
+            </Portal>
+          );
+          const instance = wrapper.instance();
+          spy(instance, 'closePortal');
+          wrapper.find('button').simulate('click');
+          assert(!instance.closePortal.called);
+        });
+      });
+    });
+
+    context('if true', () => {
+      context('if the portal is closed', () => {
+        it('should open portal when clicking openByClickOn element', () => {
+          const openByClickOn = <button>button</button>;
+          const wrapper = mount(
+            <Portal openByClickOn={openByClickOn} togglesOnClick isOpened={false}>
+              <p>Hi</p>
+            </Portal>
+          );
+          const instance = wrapper.instance();
+          spy(instance, 'openPortal');
+          wrapper.find('button').simulate('click');
+          assert(instance.openPortal.calledOnce);
+        });
+      });
+
+      context('if the portal is opened', () => {
+        it('should close portal when clicking openByClickOn element', () => {
+          const openByClickOn = <button>button</button>;
+          const wrapper = mount(
+            <Portal openByClickOn={openByClickOn} togglesOnClick isOpened>
+              <p>Hi</p>
+            </Portal>
+          );
+          const instance = wrapper.instance();
+          spy(instance, 'closePortal');
+          wrapper.find('button').simulate('click');
+          assert(instance.closePortal.calledOnce);
+        });
+      });
+    });
+  });
+
   describe('close actions', () => {
     it('Portal.closePortal()', () => {
       const wrapper = mount(<Portal isOpened><p>Hi</p></Portal>);


### PR DESCRIPTION
Adds `togglesOnClick` prop, allowing the `openByClickOn` element to toggle the portal on subsequent clicks instead of just keep it open.
