### PR TITLE
Add support to react 15.4.0

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM, { findDOMNode } from 'react-dom';
-import CSSPropertyOperations from 'react/lib/CSSPropertyOperations';
+import CSSPropertyOperations from 'react-dom/lib/CSSPropertyOperations';
 import shallowCompare from 'react/lib/shallowCompare';
 
 const KEYCODES = {


### PR DESCRIPTION
Hello! Since react 15.4.0 `CSSPropertyOperations` was moved from `react` module to `react-dom`. Tests seems ok!