### PR TITLE
Supporting className on wrapper node for 3.x.x

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -121,7 +121,10 @@ export default class Portal extends React.Component {
   }
 
   applyClassName(props) {
-    this.node.className = (props.className ? props.className : '');
+    const newClassName = (props.className ? props.className : '');
+    if (this.node.className !== newClassName) {
+      this.node.className = newClassName;
+    }
   }
 
   renderPortal(props) {

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -120,10 +120,19 @@ export default class Portal extends React.Component {
     }
   }
 
+  applyClassName(props) {
+    this.node.className = (props.className ? props.className : '');
+  }
+
   renderPortal(props) {
     if (!this.node) {
       this.node = document.createElement('div');
+      // apply CSS before the node is added to the DOM to avoid needless reflows
+      this.applyClassName(props);
       document.body.appendChild(this.node);
+    } else {
+      // update CSS when new props arrive
+      this.applyClassName(props);
     }
 
     let children = props.children;
@@ -149,6 +158,7 @@ export default class Portal extends React.Component {
 }
 
 Portal.propTypes = {
+  className: React.PropTypes.string,
   children: React.PropTypes.element.isRequired,
   openByClickOn: React.PropTypes.element,
   closeOnEsc: React.PropTypes.bool,

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -72,21 +72,27 @@ describe('react-portal', () => {
     assert.equal(closePortal, wrapper.instance().closePortal);
   });
 
-  // style & className were removed in 3.0
-  it('should not add className to the portal\'s wrapper', () => {
+  it('should add className to the portal\'s wrapper', () => {
     mount(<Portal className="some-class" isOpened><p>Hi</p></Portal>);
-    assert.notEqual(document.body.lastElementChild.className, 'some-class');
+    assert.equal(document.body.lastElementChild.className, 'some-class');
   });
 
+  // style was removed in 3.0
   it('should not add inline style to the portal\'s wrapper', () => {
     mount(<Portal isOpened style={{ color: 'blue' }}><p>Hi</p></Portal>);
     assert.notEqual(document.body.lastElementChild.style.color, 'blue');
   });
 
-  it('should not update className on the portal\'s wrapper when props.className changes', () => {
+  it('should update className on the portal\'s wrapper when props.className changes', () => {
     const wrapper = mount(<Portal className="some-class" isOpened><p>Hi</p></Portal>);
     wrapper.setProps({ className: 'some-other-class', children: <p>Hi</p> });
-    assert.notEqual(document.body.lastElementChild.className, 'some-other-class');
+    assert.equal(document.body.lastElementChild.className, 'some-other-class');
+  });
+
+  it('should remove className on the portal\'s wrapper when props.className changes', () => {
+    const wrapper = mount(<Portal className="some-class" isOpened><p>Hi</p></Portal>);
+    wrapper.setProps({ className: undefined, children: <p>Hi</p> });
+    assert.equal(document.body.lastElementChild.className, '');
   });
 
   it('should not update inline style on the portal\'s wrapper when props.style changes', () => {


### PR DESCRIPTION
className support has been removed as a breaking change in 3.0.0 but I think it was a breaking change that is annoying me in my application, and it didn't have to get removed.

The idea of 3.0.0 was to support latest React 15.4.1 and stop usage of internal React API's, but supporting className was not using internal apis so it didn't have to be removed