### PR TITLE
TypeScript Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 sudo: false
 language: node_js
-cache:
-  directories:
-  - node_modules
 node_js:
   - "6"
   - "5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: node_js
+cache:
+  directories:
+  - node_modules
 node_js:
   - "6"
   - "5"

--- a/lib/portal.d.ts
+++ b/lib/portal.d.ts
@@ -1,12 +1,14 @@
-interface PortalProps extends __React.Props<any> {
+interface PortalProps extends React.Props<any> {
 	isOpened?: boolean;
-	openByClickOn?: __React.ReactElement<any>;
+	openByClickOn?: React.ReactElement<any>;
 	closeOnEsc?: boolean;
 	closeOnOutsideClick?: boolean;
 	onOpen?: (domNode: HTMLElement) => void;
-	onBeforeClose?: (domNode: HTMLElement, removeFromDom: () => void) => void;
+	beforeClose?: (domNode: HTMLElement, removeFromDom: () => void) => void;
 	onClose?: () => void;
 	onUpdate?: () => void;
+	closePortal?: () => void;
+	openPortal?: () => void;
 }
 
 declare const Portal: (props: PortalProps) => JSX.Element;

--- a/lib/portal.d.ts
+++ b/lib/portal.d.ts
@@ -1,0 +1,14 @@
+interface PortalProps extends __React.Props<any> {
+	isOpened?: boolean;
+	openByClickOn?: __React.ReactElement<any>;
+	closeOnEsc?: boolean;
+	closeOnOutsideClick?: boolean;
+	onOpen?: (domNode: HTMLElement) => void;
+	onBeforeClose?: (domNode: HTMLElement, removeFromDom: () => void) => void;
+	onClose?: () => void;
+	onUpdate?: () => void;
+}
+
+declare const Portal: (props: PortalProps) => JSX.Element;
+
+export = Portal;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "React component for transportation of modals, lightboxes, loading bars... to document.body",
   "main": "build/portal",
+  "types": "lib/portal.d.ts",
   "files": [
     "*.md",
     "LICENSE",
@@ -22,8 +23,8 @@
     "build:examples:webpack": "cross-env NODE_ENV=production webpack --config webpack.config.prod.babel.js",
     "clean": "rimraf build",
     "test": "mocha",
-    "lint": "mocha test/eslint_spec.js",
-    "prepublish": "cross-env NODE_ENV=production npm run build"
+    "lint": "mocha test/eslint_spec.js",    
+    "prepublish": "cross-env NODE_ENV=production npm run build"	
   },
   "tags": [
     "react"
@@ -64,6 +65,7 @@
     "rimraf": "^2.5.0",
     "sinon": "^1.17.4",
     "tween.js": "^16.3.1",
+    "@types/react": "^0.14.54",
     "webpack": "^1.13.0",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "transportation"
   ],
   "devDependencies": {
+    "@types/react": "^0.14.54",
     "babel-cli": "^6.8.0",
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.4",
@@ -65,7 +66,8 @@
     "rimraf": "^2.5.0",
     "sinon": "^1.17.4",
     "tween.js": "^16.3.1",
-    "@types/react": "^0.14.54",
+    "typescript": "^2.1.4",
+    "typescript-definition-tester": "0.0.5",
     "webpack": "^1.13.0",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "build:examples:webpack": "cross-env NODE_ENV=production webpack --config webpack.config.prod.babel.js",
     "clean": "rimraf build",
     "test": "mocha",
-    "lint": "mocha test/eslint_spec.js",    
-    "prepublish": "cross-env NODE_ENV=production npm run build"	
+    "lint": "mocha test/eslint_spec.js",
+    "prepublish": "cross-env NODE_ENV=production npm run build"
   },
   "tags": [
     "react"

--- a/test/typescript/exercise-all-props.ts
+++ b/test/typescript/exercise-all-props.ts
@@ -1,0 +1,20 @@
+import * as Portal from '../../lib/portal';
+import * as React from 'react';
+
+let beforeClosed = false;
+let closed = false;
+let removedFromDom = false;
+let openedWithDomNode;
+let updated = false;
+
+export const portal = React.createElement(Portal, {
+    isOpened: true,
+    openByClickOn: React.createElement('div'),
+    closeOnEsc: true,
+    closeOnOutsideClick: false,
+    onOpen: function (domNode: HTMLElement) { return openedWithDomNode = domNode; },
+    beforeClose: function (domNode: HTMLElement, removeFromDom: () => void) { beforeClosed = true; removeFromDom(); },
+    onClose: function () { return closed = true; },
+    onUpdate: function () { return updated = true; },
+    children: React.createElement('div')
+});

--- a/test/typescript/manually-open-and-close.ts
+++ b/test/typescript/manually-open-and-close.ts
@@ -1,0 +1,7 @@
+import * as Portal from '../../lib/portal';
+import * as React from 'react';
+
+export const portal = React.createElement(Portal);
+
+portal.props.openPortal();
+portal.props.closePortal();

--- a/test/typescript_spec.js
+++ b/test/typescript_spec.js
@@ -1,0 +1,64 @@
+import Portal from '../lib/portal';
+import { mount } from 'enzyme';
+import assert from 'assert';
+import * as tt from 'typescript-definition-tester';
+import * as ts from 'typescript';
+import * as fs from 'fs';
+
+const TYPESCRIPT_FILE_PATH = './test/typescript/exercise-all-props.ts';
+
+function getPortalInstance(callback) {
+  const jsFilePath = TYPESCRIPT_FILE_PATH.replace('.ts', '.js');
+  const program = ts.createProgram([TYPESCRIPT_FILE_PATH], {
+    noEmitOnError: true, noImplicitAny: true,
+    target: ts.ScriptTarget.ES5, module: ts.ModuleKind.CommonJS,
+  });
+
+  program.emit();
+  program.emit(undefined, () => {
+    const portal = require('./typescript/exercise-all-props.js').portal; //eslint-disable-line global-require, import/no-unresolved, max-len, spaced-comment
+
+    fs.unlink(jsFilePath, () => {
+      callback(portal);
+    });
+  });
+}
+
+describe('TypeScript', () => {
+  it('should compile correctly against the TypeScript type definitions', done => {
+    tt.compileDirectory(
+      `${__dirname}/typescript`,
+      fileName => fileName.match(/\.ts$/),
+      () => done()
+    );
+  });
+
+  describe('Creating a Portal instance with TypeScript', () => {
+    let portal;
+
+    before(done => {
+      getPortalInstance((portalFromTypeScript) => {
+        portal = portalFromTypeScript;
+        done();
+      });
+    });
+
+    it('should successfully mount', () => {
+      mount(portal);
+      assert.equal(document.body.childElementCount, 1);
+    });
+
+    it('should contain exactly the props that are allowed in Portal.propTypes', () => {
+      const supportedProps = Object.keys(Portal.propTypes);
+      const actualProps = Object.keys(portal.props);
+
+      actualProps.forEach(propName => {
+        assert.notEqual(supportedProps.indexOf(propName), -1);
+      });
+
+      supportedProps.forEach(propName => {
+        assert.notEqual(actualProps.indexOf(propName), -1);
+      });
+    });
+  });
+});

--- a/test/typescript_spec.js
+++ b/test/typescript_spec.js
@@ -8,19 +8,18 @@ import * as fs from 'fs';
 const TYPESCRIPT_FILE_PATH = './test/typescript/exercise-all-props.ts';
 
 function getPortalInstance(callback) {
-  const jsFilePath = TYPESCRIPT_FILE_PATH.replace('.ts', '.js');
-  const program = ts.createProgram([TYPESCRIPT_FILE_PATH], {
+  const compileOptions = {
     noEmitOnError: true, noImplicitAny: true,
     target: ts.ScriptTarget.ES5, module: ts.ModuleKind.CommonJS,
-  });
+  };
 
-  program.emit();
-  program.emit(undefined, () => {
-    const portal = require('./typescript/exercise-all-props.js').portal; //eslint-disable-line global-require, import/no-unresolved, max-len, spaced-comment
-
-    fs.unlink(jsFilePath, () => {
-      callback(portal);
-    });
+  fs.readFile(TYPESCRIPT_FILE_PATH, 'utf-8', (err, data) => {
+    if (err) throw err;
+    const code = data.replace('../../lib', '../lib');
+    /* eslint-disable */
+    const portal = eval(ts.transpileModule(code, compileOptions).outputText);
+    /* eslint-enable */
+    callback(portal);
   });
 }
 


### PR DESCRIPTION
I am using React Portal in a TypeScript project and I ended up creating these typings. I tested these changes by cloning this repo, applying the changes in this pull request, then referencing the repo from my project via a local NPM file reference in my project's package.json.

For anyone not familiar with TypeScript, the [TypeScript docs](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) suggest that the best option is to have the typings exist in the original repo of a project so they can be more easily maintained part of the project itself as API changes occur. The typings in my PR should reflect the React Portal API as it exists now, but note that if this PR is accepted, then that will mean that all future public API changes will require updating these typings as well.

The second choice option is to publish these typings to [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) and have them be maintained separately from the original project. So, I'm trying for the best option first.