### PR TITLE
Fix race condition in render/unmount

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -75,8 +75,9 @@ export default class Portal extends React.Component {
   }
 
   openPortal(props = this.props) {
-    this.setState({ active: true });
-    this.renderPortal(props, true);
+    this.setState({ active: true }, () => {
+      this.renderPortal(props, true);
+    });
   }
 
   closePortal(isUnmounted = false) {


### PR DESCRIPTION
There is a race condition in rendering/unmounting portal.
If you open the portal and unmount parent component, `state.active` will be false. But portal will be mounted and active. This is because `this.setState()` may works async. The solution is use the 2nd `setState()` argument, that is callback.

