### PR TITLE
build to UMD format

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,11 @@
 {
   "presets": ["react", "es2015"],
-  "plugins": ["transform-es2015-modules-umd"],
   "env": {
     "development": {
       "presets": ["react-hmre"]
+    },
+    "production": {
+      "plugins": ["transform-es2015-modules-umd"]
     }
   }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": ["react", "es2015"],
-  "plugins": ["add-module-exports"],
+  "plugins": ["transform-es2015-modules-umd"],
   "env": {
     "development": {
       "presets": ["react-hmre"]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.1",
-    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-es2015-modules-umd": "^6.18.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.0.1",


### PR DESCRIPTION
This was originally proposed in https://github.com/tajo/react-portal/pull/79, but was closed due to the dependencies on internal react libraries. These have since been removed in https://github.com/tajo/react-portal/commit/e02033099af03a53262bf43110b7adf84f75d273, so I'd like to re-propose this change.