### PR TITLE
closeOnOutsideClick with right click

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -24,7 +24,7 @@ export default class Portal extends React.Component {
     }
 
     if (this.props.closeOnOutsideClick) {
-      document.addEventListener('mouseup', this.handleOutsideMouseClick);
+      document.addEventListener('mousedown', this.handleOutsideMouseClick);
       document.addEventListener('touchstart', this.handleOutsideMouseClick);
     }
 
@@ -60,7 +60,7 @@ export default class Portal extends React.Component {
     }
 
     if (this.props.closeOnOutsideClick) {
-      document.removeEventListener('mouseup', this.handleOutsideMouseClick);
+      document.removeEventListener('mousedown', this.handleOutsideMouseClick);
       document.removeEventListener('touchstart', this.handleOutsideMouseClick);
     }
 

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -14,6 +14,7 @@ export default class Portal extends React.Component {
     this.closePortal = this.closePortal.bind(this);
     this.handleOutsideMouseClick = this.handleOutsideMouseClick.bind(this);
     this.handleKeydown = this.handleKeydown.bind(this);
+    this.triggerElementRef = this.triggerElementRef.bind(this);
     this.portal = null;
     this.node = null;
   }
@@ -107,7 +108,7 @@ export default class Portal extends React.Component {
     if (!this.state.active) { return; }
 
     const root = findDOMNode(this.portal);
-    if (root.contains(e.target)) { return; }
+    if (root.contains(e.target) || e.target === this.triggerElement) { return; }
 
     e.stopPropagation();
     this.closePortal();
@@ -116,6 +117,16 @@ export default class Portal extends React.Component {
   handleKeydown(e) {
     if (e.keyCode === KEYCODES.ESCAPE && this.state.active) {
       this.closePortal();
+    }
+  }
+
+  triggerElementRef(triggerElement) {
+    const domElement = findDOMNode(triggerElement);
+
+    this.triggerElement = domElement;
+
+    if (typeof this.props.openByClickOn.ref === 'function') {
+      this.props.openByClickOn.ref(triggerElement);
     }
   }
 
@@ -145,7 +156,10 @@ export default class Portal extends React.Component {
 
   render() {
     if (this.props.openByClickOn) {
-      return React.cloneElement(this.props.openByClickOn, { onClick: this.handleWrapperClick });
+      return React.cloneElement(this.props.openByClickOn, {
+        onClick: this.handleWrapperClick,
+        ref: this.triggerElementRef,
+      });
     }
     return null;
   }

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -107,7 +107,7 @@ export default class Portal extends React.Component {
     if (!this.state.active) { return; }
 
     const root = findDOMNode(this.portal);
-    if (root.contains(e.target) || (e.button && e.button !== 0)) { return; }
+    if (root.contains(e.target)) { return; }
 
     e.stopPropagation();
     this.closePortal();

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -108,7 +108,15 @@ export default class Portal extends React.Component {
     if (!this.state.active) { return; }
 
     const root = findDOMNode(this.portal);
-    if (root.contains(e.target) || e.target === this.triggerElement) { return; }
+    if (
+      root.contains(e.target) ||
+      this.triggerElement && (
+        e.target === this.triggerElement ||
+        this.triggerElement.contains(e.target)
+      )
+    ) {
+      return;
+    }
 
     e.stopPropagation();
     this.closePortal();

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,9 @@
+export const triggerMouse = (node, event, button = 0) => {
+  node.dispatchEvent(
+    new window.MouseEvent(event, {
+      bubbles: true,
+      button,
+      view: window,
+    })
+  );
+};

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -223,19 +223,21 @@ describe('react-portal', () => {
       assert.equal(document.body.childElementCount, 0);
     });
 
-    it('closeOnOutsideClick', () => {
-      mount(<Portal closeOnOutsideClick isOpen><p>Hi</p></Portal>);
-      assert.equal(document.body.childElementCount, 1);
+    describe('closeOnOutsideClick', () => {
+      it('should close the portal when clicking outside with the main click', () => {
+        mount(<Portal closeOnOutsideClick isOpen><p>Hi</p></Portal>);
+        assert.equal(document.body.childElementCount, 1);
 
-      // Should not close when outside click isn't a main click
-      const rightClickMouseEvent = new window.MouseEvent('mouseup', { view: window, button: 2 });
-      document.dispatchEvent(rightClickMouseEvent);
-      assert.equal(document.body.childElementCount, 1);
+        // Should not close when outside click isn't a main click
+        const rightClickMouseEvent = new window.MouseEvent('mouseup', { view: window, button: 2 });
+        document.dispatchEvent(rightClickMouseEvent);
+        assert.equal(document.body.childElementCount, 1);
 
-      // Should close when outside click is a main click (typically left button click)
-      const leftClickMouseEvent = new window.MouseEvent('mouseup', { view: window, button: 0 });
-      document.dispatchEvent(leftClickMouseEvent);
-      assert.equal(document.body.childElementCount, 0);
+        // Should close when outside click is a main click (typically left button click)
+        const leftClickMouseEvent = new window.MouseEvent('mouseup', { view: window, button: 0 });
+        document.dispatchEvent(leftClickMouseEvent);
+        assert.equal(document.body.childElementCount, 0);
+      });
     });
   });
 });

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -237,51 +237,6 @@ describe('react-portal', () => {
           assert.equal(document.body.childElementCount, 0);
         }
       });
-
-      it('should not close the portal after manually open it on a click event handler', () => {
-        class Test extends React.Component {
-          constructor(props) {
-            super(props);
-
-            this.handleClick = this.handleClick.bind(this);
-            this.portalRef = this.portalRef.bind(this);
-          }
-
-          handleClick() {
-            this.portal.openPortal();
-          }
-
-          portalRef(portal) {
-            this.portal = portal;
-          }
-
-          render() {
-            return (
-              <div onClick={this.handleClick}>
-                <Portal
-                  closeOnOutsideClick
-                  ref={this.portalRef}
-                >
-                  <p>Hi</p>
-                </Portal>
-              </div>
-            );
-          }
-        }
-
-        // Attaches the node to test the document propagation events
-        const div = document.createElement('div');
-        document.body.appendChild(div);
-
-        render(<Test />, div);
-
-        assert.equal(document.body.children.length, 1);
-
-        triggerMouse(div.children[0], 'mousedown');
-        triggerMouse(div.children[0], 'click');
-
-        assert.equal(document.body.children.length, 2);
-      });
     });
 
     it('should not close the portal if the clicked element was his own trigger', () => {

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -237,90 +237,90 @@ describe('react-portal', () => {
           assert.equal(document.body.childElementCount, 0);
         }
       });
-    });
 
-    it('should not close the portal if the clicked element was his own trigger', () => {
-      class Test extends React.Component {
-        constructor(props) {
-          super(props);
+      it('should not close the portal if the clicked element was his own trigger', () => {
+        class Test extends React.Component {
+          constructor(props) {
+            super(props);
 
-          this.triggerRef = this.triggerRef.bind(this);
+            this.triggerRef = this.triggerRef.bind(this);
+          }
+
+          triggerRef(trigger) {
+            this.trigger = trigger;
+          }
+
+          render() {
+            return (
+              <Portal
+                closeOnOutsideClick
+                isOpen
+                openByClickOn={<button ref={this.triggerRef} />}
+                {...this.props}
+              >
+                <p>Hi</p>
+              </Portal>
+            );
+          }
         }
 
-        triggerRef(trigger) {
-          this.trigger = trigger;
+        const handleClose = spy();
+
+        // Attaches the node to test the document propagation events
+        const div = document.createElement('div');
+        document.body.appendChild(div);
+
+        const instance = render(<Test onClose={handleClose} />, div);
+
+        triggerMouse(instance.trigger, 'mousedown');
+        triggerMouse(instance.trigger, 'click');
+
+        assert(!handleClose.called);
+      });
+
+      it('should not close the portal if the clicked element is a child of his own trigger', () => {
+        class Test extends React.Component {
+          constructor(props) {
+            super(props);
+
+            this.triggerRef = this.triggerRef.bind(this);
+          }
+
+          triggerRef(trigger) {
+            this.trigger = trigger;
+          }
+
+          render() {
+            return (
+              <Portal
+                closeOnOutsideClick
+                isOpen
+                openByClickOn={
+                  <button>
+                    <span ref={this.triggerRef} />
+                  </button>
+                }
+                {...this.props}
+              >
+                <p>Hi</p>
+              </Portal>
+            );
+          }
         }
 
-        render() {
-          return (
-            <Portal
-              closeOnOutsideClick
-              isOpen
-              openByClickOn={<button ref={this.triggerRef} />}
-              {...this.props}
-            >
-              <p>Hi</p>
-            </Portal>
-          );
-        }
-      }
+        const handleClose = spy();
 
-      const handleClose = spy();
+        // Attaches the node to test the document propagation events
+        const div = document.createElement('div');
+        document.body.appendChild(div);
 
-      // Attaches the node to test the document propagation events
-      const div = document.createElement('div');
-      document.body.appendChild(div);
+        const instance = render(<Test onClose={handleClose} />, div);
 
-      const instance = render(<Test onClose={handleClose} />, div);
+        triggerMouse(instance.trigger, 'mousedown', 0, instance.trigger);
+        triggerMouse(instance.trigger, 'click');
 
-      triggerMouse(instance.trigger, 'mousedown');
-      triggerMouse(instance.trigger, 'click');
-
-      assert(!handleClose.called);
-    });
-
-    it('should not close the portal if the clicked element is a child of his own trigger', () => {
-      class Test extends React.Component {
-        constructor(props) {
-          super(props);
-
-          this.triggerRef = this.triggerRef.bind(this);
-        }
-
-        triggerRef(trigger) {
-          this.trigger = trigger;
-        }
-
-        render() {
-          return (
-            <Portal
-              closeOnOutsideClick
-              isOpen
-              openByClickOn={
-                <button>
-                  <span ref={this.triggerRef} />
-                </button>
-              }
-              {...this.props}
-            >
-              <p>Hi</p>
-            </Portal>
-          );
-        }
-      }
-
-      const handleClose = spy();
-
-      // Attaches the node to test the document propagation events
-      const div = document.createElement('div');
-      document.body.appendChild(div);
-
-      const instance = render(<Test onClose={handleClose} />, div);
-
-      triggerMouse(instance.trigger, 'mousedown', 0, instance.trigger);
-      triggerMouse(instance.trigger, 'click');
-
-      assert(!handleClose.called);
+        assert(!handleClose.called);
+      });
     });
   });
 });

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -225,17 +225,15 @@ describe('react-portal', () => {
     });
 
     describe('closeOnOutsideClick', () => {
-      it('should close the portal when clicking outside with the main click', () => {
-        mount(<Portal closeOnOutsideClick isOpen><p>Hi</p></Portal>);
-        assert.equal(document.body.childElementCount, 1);
+      it('should close the portal when clicking with any mouse button', () => {
+        const component = mount(<Portal closeOnOutsideClick><p>Hi</p></Portal>);
 
-        // Should not close when outside click isn't a main click
-        triggerMouse(document, 'mousedown', 2);
-        assert.equal(document.body.childElementCount, 1);
-
-        // Should close when outside click is a main click (typically left button click)
-        triggerMouse(document, 'mousedown');
-        assert.equal(document.body.childElementCount, 0);
+        for (let i = 0; i <= 4; i++) {
+          component.instance().openPortal();
+          assert.equal(document.body.childElementCount, 1);
+          triggerMouse(document, 'mousedown', i);
+          assert.equal(document.body.childElementCount, 0);
+        }
       });
 
       it('should not close the portal after manually open it on a click event handler', () => {

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -230,11 +230,11 @@ describe('react-portal', () => {
         assert.equal(document.body.childElementCount, 1);
 
         // Should not close when outside click isn't a main click
-        triggerMouse(document, 'mouseup', 2);
+        triggerMouse(document, 'mousedown', 2);
         assert.equal(document.body.childElementCount, 1);
 
         // Should close when outside click is a main click (typically left button click)
-        triggerMouse(document, 'mouseup');
+        triggerMouse(document, 'mousedown');
         assert.equal(document.body.childElementCount, 0);
       });
 
@@ -277,8 +277,8 @@ describe('react-portal', () => {
 
         assert.equal(document.body.children.length, 1);
 
+        triggerMouse(document, 'mousedown');
         triggerMouse(div.children[0], 'click');
-        triggerMouse(document, 'mouseup');
 
         assert.equal(document.body.children.length, 2);
       });

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -284,7 +284,7 @@ describe('react-portal', () => {
       });
     });
 
-    it('should not close the portal if the clicked element was is own trigger', () => {
+    it('should not close the portal if the clicked element was his own trigger', () => {
       class Test extends React.Component {
         constructor(props) {
           super(props);
@@ -319,6 +319,50 @@ describe('react-portal', () => {
       const instance = render(<Test onClose={handleClose} />, div);
 
       triggerMouse(instance.trigger, 'mousedown');
+      triggerMouse(instance.trigger, 'click');
+
+      assert(!handleClose.called);
+    });
+
+    it('should not close the portal if the clicked element is a child of his own trigger', () => {
+      class Test extends React.Component {
+        constructor(props) {
+          super(props);
+
+          this.triggerRef = this.triggerRef.bind(this);
+        }
+
+        triggerRef(trigger) {
+          this.trigger = trigger;
+        }
+
+        render() {
+          return (
+            <Portal
+              closeOnOutsideClick
+              isOpen
+              openByClickOn={
+                <button>
+                  <span ref={this.triggerRef} />
+                </button>
+              }
+              {...this.props}
+            >
+              <p>Hi</p>
+            </Portal>
+          );
+        }
+      }
+
+      const handleClose = spy();
+
+      // Attaches the node to test the document propagation events
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+
+      const instance = render(<Test onClose={handleClose} />, div);
+
+      triggerMouse(instance.trigger, 'mousedown', 0, instance.trigger);
       triggerMouse(instance.trigger, 'click');
 
       assert(!handleClose.called);


### PR DESCRIPTION
Opening a portal from an `onContextMenu` handler doesn't close previously opened portals with `closeOnOutsideClick`.

Something related to this was discussed in #55 and right clicking on the portal contents still works as expected (you can select Inspect from the context menu).

The following is a full working example running against the master branch.

```es6
import React, { PureComponent } from 'react'
import ReactDOM from 'react-dom'
import Portal from 'react-portal'

const itemStyle = {
  border: 'black solid 1px',
  display: 'inline-block',
  width: 100,
  padding: 5,
}

const buttonStyle = {
  float: 'right',
}

class Item extends PureComponent {
  handleContext = event => {
    event.preventDefault()
    this.portal.openPortal()
  }

  portalRef = portal => {
    this.portal = portal
  }

  containerRef = container => {
    this.container = container
  }

  menuRef = menu => {
    if (menu) {
      menu.style.position = 'absolute'
      menu.style.left = `${this.container.offsetLeft}px`
    }
  }

  render() {
    return (
      <div
        onContextMenu={this.handleContext}
        style={itemStyle}
        ref={this.containerRef}
        >
        ITEM

        <Portal
          closeOnOutsideClick
          ref={this.portalRef}
          openByClickOn={<a style={buttonStyle}>...</a>}
          >
          <div ref={this.menuRef}>Menu</div>
        </Portal>
      </div>
    )
  }
}

ReactDOM.render(
  <div>
    <Item />
    <Item />
  </div>,
  document.getElementById('root')
)
```

If you right click on Item 1 and then right click on Item 2, both portals remains opened:
<img width="245" alt="Screenshot" src="https://cloud.githubusercontent.com/assets/1670771/23035041/a6539eec-f45c-11e6-8e3e-bb7f9356c5bc.png">

This doesn't happen when left clicking on the trigger buttons "...".