### PR TITLE
Use key instead of keyCode

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -1,10 +1,6 @@
 import React from 'react';
 import ReactDOM, { findDOMNode } from 'react-dom';
 
-const KEYCODES = {
-  ESCAPE: 27,
-};
-
 export default class Portal extends React.Component {
 
   constructor() {
@@ -114,7 +110,7 @@ export default class Portal extends React.Component {
   }
 
   handleKeydown(e) {
-    if (e.keyCode === KEYCODES.ESCAPE && this.state.active) {
+    if (e.key === 'Escape' && this.state.active) {
       this.closePortal();
     }
   }


### PR DESCRIPTION
Use `key` instead of `keyCode` as for `keyCode` has already deprecated.

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode