### PR TITLE
Add className to containing div

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -123,6 +123,7 @@ export default class Portal extends React.Component {
   renderPortal(props, isOpening) {
     if (!this.node) {
       this.node = document.createElement('div');
+      this.node.className = 'react-portal';
       document.body.appendChild(this.node);
     }
 


### PR DESCRIPTION
> Since this has been referenced from multiple issues, I want to add that even though react-portal does not allow _setting_ a class name, it would be beneficial to _have_ a class name for the component. 
> 
> Currently, there is no way to target the containing `<div>` wrapper. 
> 
> My use case is supporting a modal on iOS Safari. (CSS) Viewport units aren't functional/reliable with the expanding/collapsing menus and without being able to add `height: 100%` to the react-portal `<div>`, it's impossible to properly support.
> 
> https://github.com/tajo/react-portal/pull/105#issuecomment-312358868