### PR TITLE
Add props to constructor

### DIFF
--- a/src/portal.js
+++ b/src/portal.js
@@ -7,8 +7,8 @@ const KEYCODES = {
 };
 
 export default class Portal extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = { active: false };
     this.handleWrapperClick = this.handleWrapperClick.bind(this);
     this.closePortal = this.closePortal.bind(this);


### PR DESCRIPTION
Had some problems raising errors when [react-prepare](https://github.com/elierotenberg/react-prepare/blob/master/src/prepare.js#L24) tried to run the render function without props being defined.