### PR TITLE
Allow change of closeOnOutsideClick

### DIFF
--- a/src/portal.js
+++ b/src/portal.js
@@ -24,8 +24,7 @@ export default class Portal extends React.Component {
     }
 
     if (this.props.closeOnOutsideClick) {
-      document.addEventListener('mouseup', this.handleOutsideMouseClick);
-      document.addEventListener('touchstart', this.handleOutsideMouseClick);
+      this.enableOutsideClickHandler()
     }
 
     if (this.props.isOpen) {
@@ -52,6 +51,14 @@ export default class Portal extends React.Component {
     if (typeof newProps.isOpen === 'undefined' && this.state.active) {
       this.renderPortal(newProps);
     }
+
+    if (this.props.closeOnOutsideClick !== newProps.closeOnOutsideClick) {
+      if (newProps.closeOnOutsideClick) {
+        this.enableOutsideClickHandler()
+      } else {
+        this.disableOutsideClickHandler()
+      }
+    }
   }
 
   componentWillUnmount() {
@@ -60,11 +67,20 @@ export default class Portal extends React.Component {
     }
 
     if (this.props.closeOnOutsideClick) {
-      document.removeEventListener('mouseup', this.handleOutsideMouseClick);
-      document.removeEventListener('touchstart', this.handleOutsideMouseClick);
+      this.disableOutsideClickHandler()
     }
 
     this.closePortal(true);
+  }
+
+  enableOutsideClickHandler() {
+      document.addEventListener('mouseup', this.handleOutsideMouseClick);
+      document.addEventListener('touchstart', this.handleOutsideMouseClick);
+  }
+
+  disableOutsideClickHandler() {
+      document.removeEventListener('mouseup', this.handleOutsideMouseClick);
+      document.removeEventListener('touchstart', this.handleOutsideMouseClick);
   }
 
   handleWrapperClick(e) {

--- a/src/portal.js
+++ b/src/portal.js
@@ -20,7 +20,7 @@ export default class Portal extends React.Component {
 
   componentDidMount() {
     if (this.props.closeOnEsc) {
-      document.addEventListener('keydown', this.handleKeydown);
+      this.enableEscHandler()
     }
 
     if (this.props.closeOnOutsideClick) {
@@ -59,11 +59,19 @@ export default class Portal extends React.Component {
         this.disableOutsideClickHandler()
       }
     }
+
+    if (this.props.closeOnEsc !== newProps.closeOnEsc) {
+      if (newProps.closeOnEsc) {
+        this.enableEscHandler()
+      } else {
+        this.disableEscHandler()
+      }
+    }
   }
 
   componentWillUnmount() {
     if (this.props.closeOnEsc) {
-      document.removeEventListener('keydown', this.handleKeydown);
+      this.disableEscHandler()
     }
 
     if (this.props.closeOnOutsideClick) {
@@ -81,6 +89,14 @@ export default class Portal extends React.Component {
   disableOutsideClickHandler() {
       document.removeEventListener('mouseup', this.handleOutsideMouseClick);
       document.removeEventListener('touchstart', this.handleOutsideMouseClick);
+  }
+
+  enableEscHandler() {
+    document.addEventListener('keydown', this.handleKeydown);
+  }
+
+  disableEscHandler() {
+    document.removeEventListener('keydown', this.handleKeydown);
   }
 
   handleWrapperClick(e) {


### PR DESCRIPTION
This PR add support for changing `closeOnOutsideClick` once it's initially mounted.

Sometimes it's useful to control `closeOnOutsideClick` dynamically, eg. when rendering other dropdowns inside portal.