### PR TITLE
Fix #87: Override isUnmounted in resetPortalState

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ If true, the portal can be closed by the outside mouse click.
 This callback is called when the portal is opened and rendered (useful for animating the DOMNode).
 
 #### beforeClose: func(DOMNode, removeFromDOM)
-This callback is called when the closing event is triggered but it prevents normal removal from the DOM. So, you can do some DOMNode animation first and then call removeFromDOM() that removes the portal from DOM.
+This callback is called when the closing event is triggered but it prevents normal removal from the DOM. So, you can do some DOMNode animation first and then call `removeFromDOM()` that removes the portal from DOM.
+
+If you'd like to execute some async logic in beforeClose, you should pass `isUnmounted:boolean` to `removeFromDom(isUnmounted)`.
 
 #### onClose: func
 This callback is called when the portal closes and after beforeClose.

--- a/lib/portal.js
+++ b/lib/portal.js
@@ -82,14 +82,19 @@ export default class Portal extends React.Component {
   }
 
   closePortal(isUnmounted = false) {
-    const resetPortalState = () => {
+    const resetPortalState = (overrideIsUnmounted) => {
       if (this.node) {
         ReactDOM.unmountComponentAtNode(this.node);
         document.body.removeChild(this.node);
       }
       this.portal = null;
       this.node = null;
-      if (isUnmounted !== true) {
+
+      const finalIsUnmounted = overrideIsUnmounted === undefined
+        ? isUnmounted
+        : overrideIsUnmounted;
+
+      if (finalIsUnmounted !== true) {
         this.setState({ active: false });
       }
     };

--- a/test/portal_spec.js
+++ b/test/portal_spec.js
@@ -113,6 +113,45 @@ describe('react-portal', () => {
       assert(props.beforeClose.calledOnce);
     });
 
+    it('should not call setState when closePortal is called with isUnmounted = true', () => {
+      const props = { isOpened: true, beforeClose: spy((node, cb) => cb()) };
+      const wrapper = mount(<Portal {...props}><p>Hi</p></Portal>);
+      const instance = wrapper.instance();
+      spy(instance, 'setState');
+      const isUnmounted = true;
+      instance.closePortal(isUnmounted);
+      assert.equal(instance.setState.callCount, 0);
+    });
+
+    it('should not call setState if removeFromDOM is called with isUnmounted = true', () => {
+      const isUnmounted = true;
+      const props = {
+        isOpened: true,
+        beforeClose: spy((node, removeFromDOM) => removeFromDOM(isUnmounted)),
+      };
+      const wrapper = mount(<Portal {...props}><p>Hi</p></Portal>);
+      const instance = wrapper.instance();
+      spy(instance, 'setState');
+      instance.closePortal();
+      assert.equal(instance.setState.callCount, 0);
+    });
+
+    it('should use isUnmounted from removeFromDOM over isUnmounted from closePortal', () => {
+      const props = {
+        isOpened: true,
+        beforeClose: spy((node, removeFromDOM) => {
+          const isUnmounted = true;
+          removeFromDOM(isUnmounted);
+        }),
+      };
+      const wrapper = mount(<Portal {...props}><p>Hi</p></Portal>);
+      const instance = wrapper.instance();
+      spy(instance, 'setState');
+      const isUnmounted = false;
+      instance.closePortal(isUnmounted);
+      assert.equal(instance.setState.callCount, 0);
+    });
+
     it('should call props.onOpen() when portal opens', () => {
       const props = { isOpened: true, onOpen: spy() };
       const wrapper = mount(<Portal {...props}><p>Hi</p></Portal>);


### PR DESCRIPTION
# PR for `3.x`

This is fix for https://github.com/tajo/react-portal/issues/87

In the last few days I've encountered this problem in my application. Unfortunately I'm not fully ready to upgrade React to v16 and it seems that react-portal v4 is still in progress 🚀 

If PR will be accepted, may I ask you for pushing it to npm?