### PR TITLE
Don't let PortalWithState disregard props.node

### DIFF
--- a/src/PortalWithState.js
+++ b/src/PortalWithState.js
@@ -53,7 +53,7 @@ class PortalWithState extends React.Component {
     }
     return (
       <Portal
-        node={this.node}
+        node={this.props.node}
         key="react-portal"
         ref={portalNode => (this.portalNode = portalNode)}
       >


### PR DESCRIPTION
I was testing PortalWithState locally, and tried to attach it to a defined element: `<div id="root"></div>` using `node={document && document.getElementById('root')}`. 

But I noticed that PortalWithState still attached the portal to `<body>`. After some digging I found out that PortalWithState used `this.node` instead of `this.props.node`