### PR TITLE
Fixing node passthrough in PortalWithState

### DIFF
--- a/src/PortalWithState.js
+++ b/src/PortalWithState.js
@@ -53,7 +53,7 @@ class PortalWithState extends React.Component {
     }
     return (
       <Portal
-        node={this.node}
+        node={this.props.node}
         key="react-portal"
         ref={portalNode => (this.portalNode = portalNode)}
       >


### PR DESCRIPTION
`PortalWithState` is supposed to take `node` as a prop and pass it down to the underlying `Portal` component. However, it never does this. It passes `this.node`, which is never defined. Those two things together indicate to me that this is a mistake and `this.node` should be `this.props.node`.