### PR TITLE
Add a prop func to check whether a click is outside

### DIFF
--- a/lib/portal.js
+++ b/lib/portal.js
@@ -109,7 +109,13 @@ export default class Portal extends React.Component {
     if (!this.state.active) { return; }
 
     const root = findDOMNode(this.portal);
-    if (root.contains(e.target) || (e.button && e.button !== 0)) { return; }
+    if (
+      root.contains(e.target) ||
+      (e.button && e.button !== 0) ||
+      !this.props.isElementOutside(e.target)
+    ) {
+      return;
+    }
 
     e.stopPropagation();
     this.closePortal();
@@ -154,6 +160,7 @@ Portal.propTypes = {
   openByClickOn: PropTypes.element,
   closeOnEsc: PropTypes.bool,
   closeOnOutsideClick: PropTypes.bool,
+  isElementOutside: PropTypes.func,
   isOpened: PropTypes.bool,
   onOpen: PropTypes.func,
   onClose: PropTypes.func,
@@ -165,4 +172,5 @@ Portal.defaultProps = {
   onOpen: () => {},
   onClose: () => {},
   onUpdate: () => {},
+  isElementOutside: () => true,
 };


### PR DESCRIPTION
I'm running into the same scenario as described in #165. This adds an escape hatch the user can specify so the originating button doesn't count as outside.