### PR TITLE
Making event optional on openPortal

### DIFF
--- a/src/PortalWithState.js
+++ b/src/PortalWithState.js
@@ -41,7 +41,9 @@ class PortalWithState extends React.Component {
     if (this.state.active) {
       return;
     }
-    e.nativeEvent.stopImmediatePropagation();
+    if (e && e.nativeEvent) {
+      e.nativeEvent.stopImmediatePropagation();
+    }
     this.setState({ active: true }, this.props.onOpen);
   }
 


### PR DESCRIPTION
This is a partial fix for the issue discussed in https://github.com/tajo/react-portal/issues/175. I'm not sure if it's a really satisfactory solution to the stated problem, but it makes my work around a lot nicer and it seems like it would be nice to allow people to omit the `e` parameter if they want to do something fancy. It also doesn't seem particularly harmful to allow this either, since the normal use case of `onClick={openPortal}` will still work as before.