### PR TITLE
Add closeOnOutsideRightClick functionality to PortalWithState

### DIFF
--- a/__tests__/PortalWithState.js
+++ b/__tests__/PortalWithState.js
@@ -36,37 +36,39 @@ ifReact('< 16', test, test.skip)('should not mount portal by default', () => {
   );
 });
 
-ifReact('>= 16', test, test.skip)(
-  'should mount portal by default with defaultOpen',
-  () => {
-    ReactDOM.render(
-      <PortalWithState defaultOpen>
-        {({ portal }) => portal('Foo')}
-      </PortalWithState>,
-      document.getElementById('root')
-    );
-    expect(document.body.firstChild.outerHTML).toBe('<div id="root"></div>');
-    expect(document.body.lastChild.outerHTML).toBe('<div>Foo</div>');
-  }
-);
+ifReact(
+  '>= 16',
+  test,
+  test.skip
+)('should mount portal by default with defaultOpen', () => {
+  ReactDOM.render(
+    <PortalWithState defaultOpen>
+      {({ portal }) => portal('Foo')}
+    </PortalWithState>,
+    document.getElementById('root')
+  );
+  expect(document.body.firstChild.outerHTML).toBe('<div id="root"></div>');
+  expect(document.body.lastChild.outerHTML).toBe('<div>Foo</div>');
+});
 
-ifReact('< 16', test, test.skip)(
-  'should mount portal by default with defaultOpen',
-  () => {
-    ReactDOM.render(
-      <PortalWithState defaultOpen>
-        {({ portal }) => portal(<div>Foo</div>)}
-      </PortalWithState>,
-      document.getElementById('root')
-    );
-    expect(document.body.firstChild.outerHTML).toBe(
-      '<div id="root"><!-- react-empty: 1 --></div>'
-    );
-    expect(document.body.lastChild.outerHTML).toBe(
-      '<div><div data-reactroot="">Foo</div></div>'
-    );
-  }
-);
+ifReact(
+  '< 16',
+  test,
+  test.skip
+)('should mount portal by default with defaultOpen', () => {
+  ReactDOM.render(
+    <PortalWithState defaultOpen>
+      {({ portal }) => portal(<div>Foo</div>)}
+    </PortalWithState>,
+    document.getElementById('root')
+  );
+  expect(document.body.firstChild.outerHTML).toBe(
+    '<div id="root"><!-- react-empty: 1 --></div>'
+  );
+  expect(document.body.lastChild.outerHTML).toBe(
+    '<div><div data-reactroot="">Foo</div></div>'
+  );
+});
 
 ifReact('>= 16', test, test.skip)(
   'should open portal after calling openPortal',
@@ -126,56 +128,58 @@ ifReact('< 16', test, test.skip)(
   }
 );
 
-ifReact('>= 16', test, test.skip)(
-  'should close portal after calling closePortal',
-  () => {
-    ReactDOM.render(
-      <PortalWithState defaultOpen>
-        {({ portal, closePortal }) => [
+ifReact(
+  '>= 16',
+  test,
+  test.skip
+)('should close portal after calling closePortal', () => {
+  ReactDOM.render(
+    <PortalWithState defaultOpen>
+      {({ portal, closePortal }) => [
+        <button key="trigger" id="trigger" onClick={closePortal}>
+          Close
+        </button>,
+        portal('Foo')
+      ]}
+    </PortalWithState>,
+    document.getElementById('root')
+  );
+  expect(document.body.firstChild.outerHTML).toBe(
+    '<div id="root"><button id="trigger">Close</button></div>'
+  );
+  expect(document.body.lastChild.outerHTML).toBe('<div>Foo</div>');
+  document.getElementById('trigger').click();
+  expect(document.body.lastChild.outerHTML).toBe(
+    document.body.firstChild.outerHTML
+  );
+});
+
+ifReact(
+  '< 16',
+  test,
+  test.skip
+)('should close portal after calling closePortal', () => {
+  ReactDOM.render(
+    <PortalWithState defaultOpen>
+      {({ portal, closePortal }) => (
+        <div>
           <button key="trigger" id="trigger" onClick={closePortal}>
             Close
-          </button>,
-          portal('Foo')
-        ]}
-      </PortalWithState>,
-      document.getElementById('root')
-    );
-    expect(document.body.firstChild.outerHTML).toBe(
-      '<div id="root"><button id="trigger">Close</button></div>'
-    );
-    expect(document.body.lastChild.outerHTML).toBe('<div>Foo</div>');
-    document.getElementById('trigger').click();
-    expect(document.body.lastChild.outerHTML).toBe(
-      document.body.firstChild.outerHTML
-    );
-  }
-);
-
-ifReact('< 16', test, test.skip)(
-  'should close portal after calling closePortal',
-  () => {
-    ReactDOM.render(
-      <PortalWithState defaultOpen>
-        {({ portal, closePortal }) => (
-          <div>
-            <button key="trigger" id="trigger" onClick={closePortal}>
-              Close
-            </button>
-            {portal(<div>Foo</div>)}
-          </div>
-        )}
-      </PortalWithState>,
-      document.getElementById('root')
-    );
-    expect(document.body.firstChild.outerHTML).toBe(
-      '<div id="root"><div data-reactroot=""><button id="trigger">Close</button><!-- react-empty: 3 --></div></div>'
-    );
-    expect(document.body.lastChild.outerHTML).toBe(
-      '<div><div data-reactroot="">Foo</div></div>'
-    );
-    document.getElementById('trigger').click();
-    expect(document.body.lastChild.outerHTML).toBe(
-      document.body.firstChild.outerHTML
-    );
-  }
-);
+          </button>
+          {portal(<div>Foo</div>)}
+        </div>
+      )}
+    </PortalWithState>,
+    document.getElementById('root')
+  );
+  expect(document.body.firstChild.outerHTML).toBe(
+    '<div id="root"><div data-reactroot=""><button id="trigger">Close</button><!-- react-empty: 3 --></div></div>'
+  );
+  expect(document.body.lastChild.outerHTML).toBe(
+    '<div><div data-reactroot="">Foo</div></div>'
+  );
+  document.getElementById('trigger').click();
+  expect(document.body.lastChild.outerHTML).toBe(
+    document.body.firstChild.outerHTML
+  );
+});

--- a/examples/index.js
+++ b/examples/index.js
@@ -28,8 +28,7 @@ export default class App extends React.Component {
           onClick={() =>
             this.setState(prevState => ({
               isPortalOneActive: !prevState.isPortalOneActive
-            }))
-          }
+            }))}
         >
           Toggle
         </button>
@@ -44,8 +43,7 @@ export default class App extends React.Component {
           onClick={() =>
             this.setState(prevState => ({
               isPortalTwoActive: !prevState.isPortalTwoActive
-            }))
-          }
+            }))}
         >
           Toggle
         </button>

--- a/src/PortalWithState.js
+++ b/src/PortalWithState.js
@@ -2,9 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Portal from './PortalCompat';
 
-const KEYCODES = {
-  ESCAPE: 27
-};
+const KEYCODES = { ESCAPE: 27 };
 
 class PortalWithState extends React.Component {
   constructor(props) {
@@ -15,6 +13,9 @@ class PortalWithState extends React.Component {
     this.closePortal = this.closePortal.bind(this);
     this.wrapWithPortal = this.wrapWithPortal.bind(this);
     this.handleOutsideMouseClick = this.handleOutsideMouseClick.bind(this);
+    this.handleOutsideMouseRightClick = this.handleOutsideMouseRightClick.bind(
+      this
+    );
     this.handleKeydown = this.handleKeydown.bind(this);
   }
 
@@ -25,6 +26,12 @@ class PortalWithState extends React.Component {
     if (this.props.closeOnOutsideClick) {
       document.addEventListener('click', this.handleOutsideMouseClick);
     }
+    if (this.props.closeOnOutsideRightClick) {
+      document.addEventListener(
+        'contextmenu',
+        this.handleOutsideMouseRightClick
+      );
+    }
   }
 
   componentWillUnmount() {
@@ -33,6 +40,12 @@ class PortalWithState extends React.Component {
     }
     if (this.props.closeOnOutsideClick) {
       document.removeEventListener('click', this.handleOutsideMouseClick);
+    }
+    if (this.props.closeOnOutsideRightClick) {
+      document.removeEventListener(
+        'contextmenu',
+        this.handleOutsideMouseRightClick
+      );
     }
   }
 
@@ -79,6 +92,17 @@ class PortalWithState extends React.Component {
     this.closePortal();
   }
 
+  handleOutsideMouseRightClick(e) {
+    if (!this.state.active) {
+      return;
+    }
+    const root = this.portalNode.defaultNode;
+    if (!root || root.contains(e.target) || (e.button && e.button !== 2)) {
+      return;
+    }
+    this.closePortal();
+  }
+
   handleKeydown(e) {
     if (e.keyCode === KEYCODES.ESCAPE && this.state.active) {
       this.closePortal();
@@ -102,6 +126,7 @@ PortalWithState.propTypes = {
   openByClickOn: PropTypes.element,
   closeOnEsc: PropTypes.bool,
   closeOnOutsideClick: PropTypes.bool,
+  closeOnOutsideRightClick: PropTypes.bool,
   onOpen: PropTypes.func,
   onClose: PropTypes.func
 };


### PR DESCRIPTION
@tajo , would it be possible to add support for closing a PortalWithState on an outside right-click? I read through the previously closed issues, and it appears that the portal previously closed on any outside click, but that functionality was removed by request.

Could we please add that functionality back, but make it optional? Please see the small additions I've added to the PortalWithState component. Thanks!