### PR TITLE
issue #185: fix out of date props render bug

### DIFF
--- a/src/LegacyPortal.js
+++ b/src/LegacyPortal.js
@@ -10,7 +10,7 @@ export default class Portal extends React.Component {
     this.renderPortal();
   }
 
-  componentWillReceiveProps(props) {
+  componentDidUpdate(props) {
     this.renderPortal();
   }
 


### PR DESCRIPTION
Related to #185 - I was observing props passed down to child components as being out of date by one render cycle.

This was because the render was called before the new props had been received.

Another way of approaching this would be to make `renderPortal` make use of the new props (they are an argument that's not used), but this also works.