### PR TITLE
fix outside click closing bug for PortalWithState

### DIFF
--- a/src/PortalWithState.js
+++ b/src/PortalWithState.js
@@ -72,7 +72,7 @@ class PortalWithState extends React.Component {
     if (!this.state.active) {
       return;
     }
-    const root = this.portalNode.defaultNode;
+    const root = this.portalNode.props.node || this.protalNode.defaultNode;
     if (!root || root.contains(e.target) || (e.button && e.button !== 0)) {
       return;
     }


### PR DESCRIPTION
When property `node` was set for `<PortalWithState />`, click outside the portal will not close properly~  Because the `defaultNode` does not exist if `props.node` defined