### PR TITLE
Fixed Portal content not being removed on toggle in React < 16

### DIFF
--- a/__tests__/Portal.js
+++ b/__tests__/Portal.js
@@ -70,3 +70,19 @@ ifReact('< 16', test, test.skip)(
     );
   }
 );
+
+ifReact(
+  '< 16',
+  test,
+  test.skip
+)('should remove portal content from custom node', () => {
+  document.body.innerHTML = '<div id="root"></div><div id="custom"></div>';
+  ReactDOM.render(
+    <Portal node={document.getElementById('custom')}>
+      <div>Foo</div>
+    </Portal>,
+    document.getElementById('root')
+  );
+  ReactDOM.unmountComponentAtNode(document.getElementById('root'));
+  expect(document.getElementById('custom').innerHTML).toBe('');
+});

--- a/examples/index.js
+++ b/examples/index.js
@@ -51,7 +51,7 @@ export default class App extends React.Component {
         </button>
         {this.state.isPortalTwoActive && (
           <Portal node={document && document.getElementById('user-node')}>
-            <p>This thing was portaled!</p>
+            <p>This thing was portaled with custom node!</p>
           </Portal>
         )}
 

--- a/src/LegacyPortal.js
+++ b/src/LegacyPortal.js
@@ -17,6 +17,9 @@ export default class Portal extends React.Component {
   componentWillUnmount() {
     if (this.defaultNode) {
       document.body.removeChild(this.defaultNode);
+    } else {
+      // Unmount the children rendered in custom node
+      ReactDOM.unmountComponentAtNode(this.props.node);
     }
     this.defaultNode = null;
     this.portal = null;


### PR DESCRIPTION
Removes portal content using `ReactDOM.unmountComponentAtNode` for React < 16.