### PR TITLE
Fixed unmount lifecycle hooks not getting called when defaultNode is used

### DIFF
--- a/src/LegacyPortal.js
+++ b/src/LegacyPortal.js
@@ -15,11 +15,9 @@ export default class Portal extends React.Component {
   }
 
   componentWillUnmount() {
+    ReactDOM.unmountComponentAtNode(this.defaultNode || this.props.node);
     if (this.defaultNode) {
       document.body.removeChild(this.defaultNode);
-    } else {
-      // Unmount the children rendered in custom node
-      ReactDOM.unmountComponentAtNode(this.props.node);
     }
     this.defaultNode = null;
     this.portal = null;


### PR DESCRIPTION
Fixes the issue mentioned here: https://github.com/tajo/react-portal/pull/199#issuecomment-373294528