### PR TITLE
Fix portal import from react-dom

### DIFF
--- a/src/Portal.js
+++ b/src/Portal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { createPortal } from 'react-dom';
+import ReactDOM from 'react-dom';
 import { canUseDOM } from './utils';
 
 class Portal extends React.Component {
@@ -19,7 +19,7 @@ class Portal extends React.Component {
       this.defaultNode = document.createElement('div');
       document.body.appendChild(this.defaultNode);
     }
-    return createPortal(
+    return ReactDOM.createPortal(
       this.props.children,
       this.props.node || this.defaultNode
     );


### PR DESCRIPTION
react-dom has no named export `createPortal`, instead it only has a default export. See the implementation here: https://github.com/facebook/react/blob/b15b165e0798dca03492e354ebd5bcf87b711184/packages/react-dom/src/client/ReactDOM.js

Because of the named import, react-portal currently doesn't work with [Rollup](https://github.com/rollup/rollup), because it is searching for a named export and can't find one.