### PR TITLE
Add umd bundle to package

### DIFF
--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+const webpack = require('webpack');
+
+const ENV = process.env.NODE_ENV || 'production';
+
+module.exports = {
+  entry: [path.join(__dirname, './index')],
+  output: {
+    path: path.join(__dirname, '../build'),
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader'
+      }
+    ]
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify(ENV)
+      }
+    }),
+    new webpack.optimize.UglifyJsPlugin()
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "name": "react-portal",
   "version": "4.1.5",
   "description": "To make your life with React Portals easier.",
-  "main": "lib/index.js",
+  "main": "lib/commonjs/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "browser": {
+    "./lib/commonjs/index.js": "./lib/umd/index.js"
+  },
   "browserslist": "last 2 versions, ie 11",
   "files": [
     "*.md",
@@ -19,10 +22,11 @@
   "author": "Vojtech Miksu <vojtech@miksu.cz>",
   "license": "MIT",
   "scripts": {
-    "build": "npm run clean && npm run build-es && npm run build-cjs",
+    "build": "npm run clean && npm run build-es && npm run build-cjs && npm run build-umd",
     "build-es": "babel ./src --out-dir ./es",
-    "build-cjs": "cross-env BABEL_ENV=commonjs babel ./src --out-dir ./lib",
-    "build:examples": "cross-env webpack",
+    "build-cjs": "cross-env BABEL_ENV=commonjs babel ./src --out-dir ./lib/commonjs",
+    "build-umd": "cross-env BABEL_ENV=umd webpack",
+    "build:examples": "cross-env webpack --config examples/webpack.config.js",
     "clean": "rimraf es lib build",
     "prepublish": "cross-env NODE_ENV=production npm run build",
     "lint": "eslint webpack.config.js src/**/*.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,29 @@
 const path = require('path');
 const webpack = require('webpack');
 
-const ENV = process.env.NODE_ENV || 'production';
+const ENV = process.env.NODE_ENV;
 
 module.exports = {
-  entry: ['./examples/index'],
+  entry: ['./src/index'],
   output: {
-    path: path.join(__dirname, './build'),
-    filename: 'bundle.js'
+    path: path.join(__dirname, './lib', process.env.BABEL_ENV),
+    filename: 'index.js',
+    library: 'reactPortal',
+    libraryTarget: process.env.BABEL_ENV
+  },
+  externals: {
+    react: {
+      root: 'React',
+      commonjs2: 'react',
+      commonjs: 'react',
+      amd: 'react'
+    },
+    'react-dom': {
+      root: 'ReactDOM',
+      commonjs2: 'react-dom',
+      commonjs: 'react-dom',
+      amd: 'react-dom'
+    }
   },
   module: {
     rules: [
@@ -24,6 +40,8 @@ module.exports = {
         NODE_ENV: JSON.stringify(ENV)
       }
     }),
-    new webpack.optimize.UglifyJsPlugin()
-  ]
+    process.env.NODE_ENV === 'production'
+      ? new webpack.optimize.UglifyJsPlugin()
+      : null
+  ].filter(Boolean)
 };


### PR DESCRIPTION
- Move examples webpack.config.js to the /examples folder
- Move commonjs build to /lib/commonjs
- Add webpack.config.js in the root to bundle the umd build
- Add build-umd which outputs to /lib/umd
- Reference the umd build from package.json's browser field

Fixes #207 