### PR TITLE
Ability to portal into other element than document.body by overriding Portal.portalRoot

### DIFF
--- a/__tests__/Portal.js
+++ b/__tests__/Portal.js
@@ -85,6 +85,56 @@ ifReact(
   });
 });
 
+ifReact(
+  '< 16',
+  describe,
+  describe.skip
+)('specifying another portalRoot than document.body', () => {
+  let portalRoot;
+  beforeEach(() => {
+    portalRoot = document.createElement('div');
+    document.body.appendChild(portalRoot);
+    Portal.portalRoot = portalRoot;
+  });
+
+  afterAll(() => {
+    portalRoot.parentNode.removeChild(portalRoot);
+    Portal.portalRoot = document.body;
+  });
+
+  test('should render portal to the given element', () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    ReactDOM.render(
+      <Portal>
+        <div>Foo</div>
+      </Portal>,
+      document.getElementById('root')
+    );
+    expect(document.getElementById('root').outerHTML).toBe(
+      '<div id="root"><!-- react-empty: 1 --></div>'
+    );
+    expect(portalRoot.outerHTML).toBe(
+      '<div><div><div data-reactroot="">Foo</div></div></div>'
+    );
+  });
+
+  test('should remove the portal even if portalRoot has changed', () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    ReactDOM.render(
+      <Portal>
+        <div>Foo</div>
+      </Portal>,
+      document.getElementById('root')
+    );
+    Portal.portalRoot = document.body;
+    ReactDOM.render(
+      <span className="empty" />,
+      document.getElementById('root')
+    );
+    expect(portalRoot.outerHTML).toBe('<div></div>');
+  });
+});
+
 ifReact('< 16', test, test.skip)(
   'should append portal to a custom element',
   () => {

--- a/__tests__/Portal.js
+++ b/__tests__/Portal.js
@@ -52,6 +52,39 @@ ifReact('>= 16', test, test.skip)(
   }
 );
 
+ifReact(
+  '>= 16',
+  describe,
+  describe.skip
+)('can specify another portalRoot than document.body', () => {
+  let portalRoot;
+  beforeAll(() => {
+    portalRoot = document.createElement('div');
+    Portal.portalRoot = portalRoot;
+  });
+
+  afterAll(() => {
+    Portal.portalRoot = document.body;
+  });
+
+  test('should render portal to the given element', () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    ReactDOM.render(<Portal>Foo</Portal>, document.getElementById('root'));
+    expect(document.getElementById('root').outerHTML).toBe(
+      '<div id="root"></div>'
+    );
+    expect(portalRoot.outerHTML).toBe('<div><div>Foo</div></div>');
+  });
+
+  test('should remove the portal even if portalRoot has changed', () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    ReactDOM.render(<Portal>Foo</Portal>, document.getElementById('root'));
+    Portal.portalRoot = document.body;
+    ReactDOM.render(null, document.getElementById('root'));
+    expect(portalRoot.outerHTML).toBe('<div></div>');
+  });
+});
+
 ifReact('< 16', test, test.skip)(
   'should append portal to a custom element',
   () => {

--- a/src/LegacyPortal.js
+++ b/src/LegacyPortal.js
@@ -17,7 +17,7 @@ export default class Portal extends React.Component {
   componentWillUnmount() {
     ReactDOM.unmountComponentAtNode(this.defaultNode || this.props.node);
     if (this.defaultNode) {
-      document.body.removeChild(this.defaultNode);
+      this.defaultNode.parentNode.removeChild(this.defaultNode);
     }
     this.defaultNode = null;
     this.portal = null;
@@ -26,7 +26,7 @@ export default class Portal extends React.Component {
   renderPortal(props) {
     if (!this.props.node && !this.defaultNode) {
       this.defaultNode = document.createElement('div');
-      document.body.appendChild(this.defaultNode);
+      Portal.portalRoot.appendChild(this.defaultNode);
     }
 
     let children = this.props.children;
@@ -46,6 +46,8 @@ export default class Portal extends React.Component {
     return null;
   }
 }
+
+Portal.portalRoot = document.body;
 
 Portal.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/Portal.js
+++ b/src/Portal.js
@@ -6,7 +6,7 @@ import { canUseDOM } from './utils';
 class Portal extends React.Component {
   componentWillUnmount() {
     if (this.defaultNode) {
-      document.body.removeChild(this.defaultNode);
+      this.defaultNode.parentNode.removeChild(this.defaultNode);
     }
     this.defaultNode = null;
   }
@@ -17,7 +17,7 @@ class Portal extends React.Component {
     }
     if (!this.props.node && !this.defaultNode) {
       this.defaultNode = document.createElement('div');
-      document.body.appendChild(this.defaultNode);
+      Portal.portalRoot.appendChild(this.defaultNode);
     }
     return ReactDOM.createPortal(
       this.props.children,
@@ -25,6 +25,8 @@ class Portal extends React.Component {
     );
   }
 }
+
+Portal.portalRoot = document.body;
 
 Portal.propTypes = {
   children: PropTypes.node.isRequired,


### PR DESCRIPTION
This pull requests adds support for overriding Portal.portalRoot, so that instead of repeating `<Portal node={portalRoot}>...</Portal>` it can be specified once.

It is a feature I need for one of my projects, where I clone all of the html of the application (which must include all portals) to create a magnifying glass effect. Cloning document.body wasn't a good fit.

Overriding Portal.portalRoot should probably be done in the entry file.