### PR TITLE
Fixed the repeated click open button to cause the active state to switch

### DIFF
--- a/src/PortalWithState.js
+++ b/src/PortalWithState.js
@@ -37,11 +37,11 @@ class PortalWithState extends React.Component {
   }
 
   openPortal(e) {
-    if (this.state.active) {
-      return;
-    }
     if (e && e.nativeEvent) {
       e.nativeEvent.stopImmediatePropagation();
+    }
+    if (this.state.active) {
+      return;
     }
     this.setState({ active: true }, this.props.onOpen);
   }


### PR DESCRIPTION
I think that repeated click open button to switch state is a problem.
If I am wrong, I want to tell me why.
Thanks!