### PR TITLE
Spread params to onClose

### DIFF
--- a/src/PortalWithState.js
+++ b/src/PortalWithState.js
@@ -46,11 +46,15 @@ class PortalWithState extends React.Component {
     this.setState({ active: true }, this.props.onOpen);
   }
 
-  closePortal() {
+  closePortal(...args) {
     if (!this.state.active) {
       return;
     }
-    this.setState({ active: false }, this.props.onClose);
+    this.setState({ active: false }, () => {
+      if (this.props.onClose) {
+        this.props.onClose(...args);
+      }
+    });
   }
 
   wrapWithPortal(children) {


### PR DESCRIPTION
I have the following code.

I would like to pass `closePortal` directly to the `onClick` prop of `EmojiPicker` and in the `onClose` prop to `PortalWithState` receive the arguments passed by EmojiPicker, because in every render of the Popper component the EmojiPicker rerender because i am creating an inline function.

```jsx
class EmojiInputButton extends React.PureComponent {
  render() {
    return (
      <PortalWithState closeOnEsc closeOnOutsideClick>
        {({closePortal, openPortal, portal}) => (
          <Manager>
            <Reference>
              {({ref}) => (
                <Button ref={ref} type="button">
                  <FontAwesomeIcon icon={['fal', 'smile']} />
                </Button>
              )}
            </Reference>
            {portal(
              <Popper placement="auto-start">
                {({placement, ref, style}) => (
                  <div
                    data-placement={placement}
                    ref={ref}
                    style={style}
                  >
                    <EmojiPicker
                      onClick={(...args) => {
                        closePortal();

                        this.props.onSelect(...args);
                      }}
                    />
                  </div>
                )}
              </Popper>
            )}
          </Manager>
        )}
      </PortalWithState>
    );
  }
}

export default EmojiInputButton;
```