### PR TITLE
Remove unused openByClickOn proptype

### DIFF
--- a/src/PortalWithState.js
+++ b/src/PortalWithState.js
@@ -99,7 +99,6 @@ PortalWithState.propTypes = {
   children: PropTypes.func.isRequired,
   defaultOpen: PropTypes.bool,
   node: PropTypes.any,
-  openByClickOn: PropTypes.element,
   closeOnEsc: PropTypes.bool,
   closeOnOutsideClick: PropTypes.bool,
   onOpen: PropTypes.func,


### PR DESCRIPTION
Hi,

the `openByClickOn` propType is declared but never used, it's a remaining from v3 apparently.

