### PR TITLE
Open portal and fire callbacks when defaultOpen

### DIFF
--- a/src/PortalWithState.js
+++ b/src/PortalWithState.js
@@ -25,6 +25,9 @@ class PortalWithState extends React.Component {
     if (this.props.closeOnOutsideClick) {
       document.addEventListener('click', this.handleOutsideMouseClick);
     }
+    if (this.props.defaultOpen) {
+      this.props.onOpen();
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Now when rendering a portal with defaultOpen=true option, `onOpen` callback is not getting fired. I've heard, it's commonly used for adding backdrops.

In this PR we fire the callback onOpen when component gets mounted.